### PR TITLE
fix: route /presenter to presenter.html in CloudFront SPA rewrite

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -67,7 +67,11 @@ resource "aws_cloudfront_function" "spa_rewrite" {
     function handler(event) {
       var request = event.request;
       if (!request.uri.includes('.')) {
-        request.uri = '/index.html';
+        if (request.uri === '/presenter' || request.uri === '/presenter/') {
+          request.uri = '/presenter.html';
+        } else {
+          request.uri = '/index.html';
+        }
       }
       return request;
     }


### PR DESCRIPTION
## Summary
- CloudFront SPA rewrite function was routing all extensionless paths to `/index.html`, including `/presenter`
- The presenter page has its own HTML entry point (`presenter.html` with `#presenter-root`), but it was never served
- Added a condition to route `/presenter` and `/presenter/` to `/presenter.html`

## Test plan
- [ ] Deploy and verify `https://bunshin-ogadra.mad.bcr.dev/presenter` shows the presenter login form
- [ ] Verify other SPA routes still resolve to `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)