### PR TITLE
fix: correct Lambda env var names for presenter WebSocket handlers

### DIFF
--- a/presenter/cmd/connect/main.go
+++ b/presenter/cmd/connect/main.go
@@ -120,7 +120,7 @@ func (h *connectHandler) handle(ctx context.Context, req events.APIGatewayWebsoc
 	}
 
 	broadcaster := h.newBroadcaster(req.RequestContext.DomainName, req.RequestContext.Stage)
-	if err := broadcaster.Send(ctx, room, payload, ""); err != nil {
+	if err := broadcaster.Send(ctx, room, payload, connectionID); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("broadcast viewer_count: %w", err)
 	}
 

--- a/presenter/cmd/connect/main.go
+++ b/presenter/cmd/connect/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -38,11 +39,14 @@ var jsonMarshal = json.Marshal
 // room は WebSocket 接続のグループ識別子。
 const room = "default"
 
+// broadcasterFactory は requestContext からエンドポイントを構築し Broadcaster を生成する。
+type broadcasterFactory func(domainName, stage string) messageBroadcaster
+
 // connectHandler は $connect イベントを処理するハンドラー。
 type connectHandler struct {
-	connStore    connectionStore
-	sessionStore sessionValidator
-	broadcaster  messageBroadcaster
+	connStore      connectionStore
+	sessionStore   sessionValidator
+	newBroadcaster broadcasterFactory
 }
 
 // connectionStore は接続の永続化インターフェース。
@@ -115,11 +119,28 @@ func (h *connectHandler) handle(ctx context.Context, req events.APIGatewayWebsoc
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal viewer_count: %w", err)
 	}
 
-	if err := h.broadcaster.Send(ctx, room, payload, ""); err != nil {
+	broadcaster := h.newBroadcaster(req.RequestContext.DomainName, req.RequestContext.Stage)
+	if err := broadcaster.Send(ctx, room, payload, ""); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("broadcast viewer_count: %w", err)
 	}
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+// newAPIGWEndpoint は requestContext の domainName と stage からエンドポイント URL を構築する。
+func newAPIGWEndpoint(domainName, stage string) string {
+	return fmt.Sprintf("https://%s/%s", domainName, stage)
+}
+
+// newBroadcasterFactory は AWS 設定と接続ストアから broadcasterFactory を生成する。
+func newBroadcasterFactory(cfg aws.Config, connStore *connection.Store) broadcasterFactory {
+	return func(domainName, stage string) messageBroadcaster {
+		endpoint := newAPIGWEndpoint(domainName, stage)
+		apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
+			o.BaseEndpoint = &endpoint
+		})
+		return broadcast.NewBroadcaster(apigwClient, connStore, connStore)
+	}
 }
 
 // run は依存を初期化し Lambda ハンドラーを起動する。
@@ -139,22 +160,14 @@ func run() error {
 	if sessTable == "" {
 		return fmt.Errorf("SESSIONS_TABLE environment variable is required")
 	}
-	apigwEndpoint := os.Getenv("APIGW_ENDPOINT")
-
-	apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
-		if apigwEndpoint != "" {
-			o.BaseEndpoint = &apigwEndpoint
-		}
-	})
 
 	connStore := connection.NewStore(ddbClient, connTable)
 	sessStore := connection.NewSessionStore(ddbClient, sessTable)
-	b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
 
 	h := &connectHandler{
-		connStore:    connStore,
-		sessionStore: sessStore,
-		broadcaster:  b,
+		connStore:      connStore,
+		sessionStore:   sessStore,
+		newBroadcaster: newBroadcasterFactory(cfg, connStore),
 	}
 
 	startLambda(h.handle)

--- a/presenter/cmd/connect/main_test.go
+++ b/presenter/cmd/connect/main_test.go
@@ -367,17 +367,13 @@ func TestRun_Success(t *testing.T) {
 	t.Setenv("CONNECTIONS_TABLE", "conn-table")
 	t.Setenv("SESSIONS_TABLE", "sess-table")
 
-	var capturedHandler any
-	startLambda = func(handler any) { capturedHandler = handler }
+	startLambda = func(handler any) {}
 	loadConfig = func(_ context.Context, _ ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, nil
 	}
 
 	if err := run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if capturedHandler == nil {
-		t.Fatal("expected handler to be registered")
 	}
 }
 

--- a/presenter/cmd/connect/main_test.go
+++ b/presenter/cmd/connect/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
 	"github.com/ogadra/20260327-cli-demo/presenter/internal/connection"
 )
@@ -81,10 +82,12 @@ func TestHandle_ViewerConnect(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return nil
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return nil
+				},
+			}
 		},
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
@@ -121,10 +124,12 @@ func TestHandle_PresenterConnect(t *testing.T) {
 				return token == "valid-token", nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return nil
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return nil
+				},
+			}
 		},
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn2", "slide_auth=valid-token"))
@@ -158,10 +163,12 @@ func TestHandle_CookieHeaderCapital(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return nil
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return nil
+				},
+			}
 		},
 	}
 	req := events.APIGatewayWebsocketProxyRequest{
@@ -191,7 +198,7 @@ func TestHandle_SessionValidateError(t *testing.T) {
 				return false, fmt.Errorf("session error")
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
 	if err == nil {
@@ -216,7 +223,7 @@ func TestHandle_PutError(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
 	if err == nil {
@@ -244,7 +251,7 @@ func TestHandle_CountError(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
 	if err == nil {
@@ -272,10 +279,12 @@ func TestHandle_BroadcastError(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return fmt.Errorf("broadcast error")
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return fmt.Errorf("broadcast error")
+				},
+			}
 		},
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
@@ -335,7 +344,7 @@ func TestHandle_MarshalError(t *testing.T) {
 				return false, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1", ""))
 	if err == nil {
@@ -358,36 +367,29 @@ func TestRun_Success(t *testing.T) {
 	t.Setenv("CONNECTIONS_TABLE", "conn-table")
 	t.Setenv("SESSIONS_TABLE", "sess-table")
 
-	startLambda = func(handler any) {}
+	var capturedHandler any
+	startLambda = func(handler any) { capturedHandler = handler }
 	loadConfig = func(_ context.Context, _ ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, nil
 	}
 
 	if err := run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedHandler == nil {
+		t.Fatal("expected handler to be registered")
 	}
 }
 
-// TestRun_SuccessWithEndpoint は APIGW_ENDPOINT が設定されている場合に run が正常に完了することを検証する。
-func TestRun_SuccessWithEndpoint(t *testing.T) {
-	origStart := startLambda
-	origLoadConfig := loadConfig
-	defer func() {
-		startLambda = origStart
-		loadConfig = origLoadConfig
-	}()
-
-	t.Setenv("CONNECTIONS_TABLE", "conn-table")
-	t.Setenv("SESSIONS_TABLE", "sess-table")
-	t.Setenv("APIGW_ENDPOINT", "https://example.com")
-
-	startLambda = func(handler any) {}
-	loadConfig = func(_ context.Context, _ ...func(*config.LoadOptions) error) (aws.Config, error) {
-		return aws.Config{}, nil
-	}
-
-	if err := run(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestNewBroadcasterFactory は newBroadcasterFactory が Broadcaster を返すことを検証する。
+func TestNewBroadcasterFactory(t *testing.T) {
+	t.Parallel()
+	cfg := aws.Config{}
+	connStore := connection.NewStore(dynamodb.NewFromConfig(cfg), "test-table")
+	factory := newBroadcasterFactory(cfg, connStore)
+	b := factory("example.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	if b == nil {
+		t.Fatal("expected broadcaster to be non-nil")
 	}
 }
 
@@ -450,6 +452,16 @@ func TestRun_ConfigError(t *testing.T) {
 
 	if err := run(); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// TestNewAPIGWEndpoint は requestContext からエンドポイント URL を構築することを検証する。
+func TestNewAPIGWEndpoint(t *testing.T) {
+	t.Parallel()
+	got := newAPIGWEndpoint("abc123.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	expected := "https://abc123.execute-api.ap-northeast-1.amazonaws.com/ws"
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
 	}
 }
 

--- a/presenter/cmd/disconnect/main.go
+++ b/presenter/cmd/disconnect/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -37,10 +38,13 @@ var jsonMarshal = json.Marshal
 // room は WebSocket 接続のグループ識別子。
 const room = "default"
 
+// broadcasterFactory は requestContext からエンドポイントを構築し Broadcaster を生成する。
+type broadcasterFactory func(domainName, stage string) messageBroadcaster
+
 // disconnectHandler は $disconnect イベントを処理するハンドラー。
 type disconnectHandler struct {
-	connStore   connectionManager
-	broadcaster messageBroadcaster
+	connStore      connectionManager
+	newBroadcaster broadcasterFactory
 }
 
 // connectionManager は接続の削除とカウントのインターフェース。
@@ -76,11 +80,28 @@ func (h *disconnectHandler) handle(ctx context.Context, req events.APIGatewayWeb
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal viewer_count: %w", err)
 	}
 
-	if err := h.broadcaster.Send(ctx, room, payload, ""); err != nil {
+	broadcaster := h.newBroadcaster(req.RequestContext.DomainName, req.RequestContext.Stage)
+	if err := broadcaster.Send(ctx, room, payload, ""); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("broadcast viewer_count: %w", err)
 	}
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+// newAPIGWEndpoint は requestContext の domainName と stage からエンドポイント URL を構築する。
+func newAPIGWEndpoint(domainName, stage string) string {
+	return fmt.Sprintf("https://%s/%s", domainName, stage)
+}
+
+// newBroadcasterFactory は AWS 設定と接続ストアから broadcasterFactory を生成する。
+func newBroadcasterFactory(cfg aws.Config, connStore *connection.Store) broadcasterFactory {
+	return func(domainName, stage string) messageBroadcaster {
+		endpoint := newAPIGWEndpoint(domainName, stage)
+		apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
+			o.BaseEndpoint = &endpoint
+		})
+		return broadcast.NewBroadcaster(apigwClient, connStore, connStore)
+	}
 }
 
 // run は依存を初期化し Lambda ハンドラーを起動する。
@@ -96,20 +117,12 @@ func run() error {
 	if connTable == "" {
 		return fmt.Errorf("CONNECTIONS_TABLE environment variable is required")
 	}
-	apigwEndpoint := os.Getenv("APIGW_ENDPOINT")
-
-	apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
-		if apigwEndpoint != "" {
-			o.BaseEndpoint = &apigwEndpoint
-		}
-	})
 
 	connStore := connection.NewStore(ddbClient, connTable)
-	b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
 
 	h := &disconnectHandler{
-		connStore:   connStore,
-		broadcaster: b,
+		connStore:      connStore,
+		newBroadcaster: newBroadcasterFactory(cfg, connStore),
 	}
 
 	startLambda(h.handle)

--- a/presenter/cmd/disconnect/main_test.go
+++ b/presenter/cmd/disconnect/main_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"github.com/ogadra/20260327-cli-demo/presenter/internal/connection"
 )
 
 // mockConnectionManager は connectionManager のモック。
@@ -59,10 +62,12 @@ func TestHandle_Success(t *testing.T) {
 				return 0, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return nil
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return nil
+				},
+			}
 		},
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1"))
@@ -86,7 +91,7 @@ func TestHandle_DeleteError(t *testing.T) {
 				return fmt.Errorf("delete error")
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1"))
 	if err == nil {
@@ -109,7 +114,7 @@ func TestHandle_CountError(t *testing.T) {
 				return 0, fmt.Errorf("count error")
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1"))
 	if err == nil {
@@ -132,10 +137,12 @@ func TestHandle_BroadcastError(t *testing.T) {
 				return 5, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{
-			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
-				return fmt.Errorf("broadcast error")
-			},
+		newBroadcaster: func(_, _ string) messageBroadcaster {
+			return &mockBroadcaster{
+				sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+					return fmt.Errorf("broadcast error")
+				},
+			}
 		},
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1"))
@@ -163,7 +170,7 @@ func TestHandle_MarshalError(t *testing.T) {
 				return 1, nil
 			},
 		},
-		broadcaster: &mockBroadcaster{},
+		newBroadcaster: func(_, _ string) messageBroadcaster { return &mockBroadcaster{} },
 	}
 	resp, err := h.handle(context.Background(), newRequest("conn1"))
 	if err == nil {
@@ -195,25 +202,25 @@ func TestRun_Success(t *testing.T) {
 	}
 }
 
-// TestRun_SuccessWithEndpoint は APIGW_ENDPOINT が設定されている場合に run が正常に完了することを検証する。
-func TestRun_SuccessWithEndpoint(t *testing.T) {
-	origStart := startLambda
-	origLoadConfig := loadConfig
-	defer func() {
-		startLambda = origStart
-		loadConfig = origLoadConfig
-	}()
-
-	t.Setenv("CONNECTIONS_TABLE", "conn-table")
-	t.Setenv("APIGW_ENDPOINT", "https://example.com")
-
-	startLambda = func(handler any) {}
-	loadConfig = func(_ context.Context, _ ...func(*config.LoadOptions) error) (aws.Config, error) {
-		return aws.Config{}, nil
+// TestNewBroadcasterFactory は newBroadcasterFactory が Broadcaster を返すことを検証する。
+func TestNewBroadcasterFactory(t *testing.T) {
+	t.Parallel()
+	cfg := aws.Config{}
+	connStore := connection.NewStore(dynamodb.NewFromConfig(cfg), "test-table")
+	factory := newBroadcasterFactory(cfg, connStore)
+	b := factory("example.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	if b == nil {
+		t.Fatal("expected broadcaster to be non-nil")
 	}
+}
 
-	if err := run(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestNewAPIGWEndpoint は requestContext からエンドポイント URL を構築することを検証する。
+func TestNewAPIGWEndpoint(t *testing.T) {
+	t.Parallel()
+	got := newAPIGWEndpoint("abc123.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	expected := "https://abc123.execute-api.ap-northeast-1.amazonaws.com/ws"
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
 	}
 }
 

--- a/presenter/cmd/message/main.go
+++ b/presenter/cmd/message/main.go
@@ -101,18 +101,26 @@ type singleSender interface {
 	SendToOne(ctx context.Context, room, connectionID string, payload []byte) error
 }
 
-// messageHandler は $default イベントを処理するハンドラー。
-type messageHandler struct {
+// handleDepsFactory はリクエストごとの依存を生成するファクトリー。
+type handleDepsFactory func(domainName, stage string) handleDeps
+
+// handleDeps はリクエストごとに生成される依存。
+type handleDeps struct {
 	slideSync    slideSyncDispatcher
 	handsOn      handsOnDispatcher
 	viewerCount  viewerCountDispatcher
-	pollGet      pollGetter
-	pollVote     pollVoter
-	pollUnvote   pollUnvoter
-	pollSwitch   pollSwitcher
-	connGetter   connectionGetter
 	broadcaster  messageBroadcaster
 	singleSender singleSender
+}
+
+// messageHandler は $default イベントを処理するハンドラー。
+type messageHandler struct {
+	pollGet    pollGetter
+	pollVote   pollVoter
+	pollUnvote pollUnvoter
+	pollSwitch pollSwitcher
+	connGetter connectionGetter
+	newDeps    handleDepsFactory
 }
 
 // incomingMessage はクライアントからの受信メッセージ。
@@ -157,6 +165,7 @@ type errorResponse struct {
 // handle は $default イベントを処理する。
 func (h *messageHandler) handle(ctx context.Context, req events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error) {
 	connectionID := req.RequestContext.ConnectionID
+	deps := h.newDeps(req.RequestContext.DomainName, req.RequestContext.Stage)
 
 	var msg incomingMessage
 	if err := json.Unmarshal([]byte(req.Body), &msg); err != nil {
@@ -165,52 +174,52 @@ func (h *messageHandler) handle(ctx context.Context, req events.APIGatewayWebsoc
 
 	switch msg.Type {
 	case "slide_sync":
-		return h.handleSlideSync(ctx, connectionID, msg)
+		return h.handleSlideSync(ctx, connectionID, msg, deps)
 	case "hands_on":
-		return h.handleHandsOn(ctx, connectionID, msg)
+		return h.handleHandsOn(ctx, connectionID, msg, deps)
 	case "viewer_count":
-		return h.handleViewerCount(ctx, connectionID)
+		return h.handleViewerCount(ctx, connectionID, deps)
 	case "poll_get":
-		return h.handlePollGet(ctx, connectionID, msg)
+		return h.handlePollGet(ctx, connectionID, msg, deps)
 	case "poll_vote":
-		return h.handlePollVote(ctx, connectionID, msg)
+		return h.handlePollVote(ctx, connectionID, msg, deps)
 	case "poll_unvote":
-		return h.handlePollUnvote(ctx, connectionID, msg)
+		return h.handlePollUnvote(ctx, connectionID, msg, deps)
 	case "poll_switch":
-		return h.handlePollSwitch(ctx, connectionID, msg)
+		return h.handlePollSwitch(ctx, connectionID, msg, deps)
 	default:
-		return h.sendError(ctx, connectionID, "unknown message type")
+		return h.sendError(ctx, connectionID, "unknown message type", deps)
 	}
 }
 
 // handleSlideSync はスライド同期メッセージを処理する。
-func (h *messageHandler) handleSlideSync(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
-	if err := h.slideSync.Handle(ctx, room, connectionID, msg.Page); err != nil {
-		return h.sendError(ctx, connectionID, err.Error())
+func (h *messageHandler) handleSlideSync(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
+	if err := deps.slideSync.Handle(ctx, room, connectionID, msg.Page); err != nil {
+		return h.sendError(ctx, connectionID, err.Error(), deps)
 	}
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
 
 // handleHandsOn はハンズオン指示メッセージを処理する。
-func (h *messageHandler) handleHandsOn(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
-	if err := h.handsOn.Handle(ctx, room, connectionID, msg.Instruction, msg.Placeholder); err != nil {
-		return h.sendError(ctx, connectionID, err.Error())
+func (h *messageHandler) handleHandsOn(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
+	if err := deps.handsOn.Handle(ctx, room, connectionID, msg.Instruction, msg.Placeholder); err != nil {
+		return h.sendError(ctx, connectionID, err.Error(), deps)
 	}
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
 
 // handleViewerCount は接続数通知メッセージを処理する。
-func (h *messageHandler) handleViewerCount(ctx context.Context, connectionID string) (events.APIGatewayProxyResponse, error) {
-	if err := h.viewerCount.Handle(ctx, room, connectionID); err != nil {
+func (h *messageHandler) handleViewerCount(ctx context.Context, connectionID string, deps handleDeps) (events.APIGatewayProxyResponse, error) {
+	if err := deps.viewerCount.Handle(ctx, room, connectionID); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("viewer_count: %w", err)
 	}
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
 
 // handlePollGet はアンケート状態取得メッセージを処理する。
-func (h *messageHandler) handlePollGet(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) handlePollGet(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	if msg.PollID == "" {
-		return h.sendError(ctx, connectionID, "pollId is required")
+		return h.sendError(ctx, connectionID, "pollId is required", deps)
 	}
 
 	conn, err := h.connGetter.Get(ctx, room, connectionID)
@@ -222,62 +231,62 @@ func (h *messageHandler) handlePollGet(ctx context.Context, connectionID string,
 	state, err := h.pollGet.Get(ctx, msg.PollID, connectionID, msg.Options, msg.MaxChoices, isPresenter)
 	if err != nil {
 		if isPollBusinessError(err) {
-			return h.sendError(ctx, connectionID, err.Error())
+			return h.sendError(ctx, connectionID, err.Error(), deps)
 		}
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("poll_get: %w", err)
 	}
 
-	return h.sendPollState(ctx, connectionID, state)
+	return h.sendPollState(ctx, connectionID, state, deps)
 }
 
 // handlePollVote は投票メッセージを処理する。
-func (h *messageHandler) handlePollVote(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) handlePollVote(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	if msg.PollID == "" || msg.Choice == "" {
-		return h.sendError(ctx, connectionID, "pollId and choice are required")
+		return h.sendError(ctx, connectionID, "pollId and choice are required", deps)
 	}
 	err := h.pollVote.Vote(ctx, msg.PollID, connectionID, msg.Choice)
 	if err != nil {
-		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err)
+		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err, deps)
 	}
-	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID)
+	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID, deps)
 }
 
 // handlePollUnvote は投票取消メッセージを処理する。
-func (h *messageHandler) handlePollUnvote(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) handlePollUnvote(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	if msg.PollID == "" || msg.Choice == "" {
-		return h.sendError(ctx, connectionID, "pollId and choice are required")
+		return h.sendError(ctx, connectionID, "pollId and choice are required", deps)
 	}
 	err := h.pollUnvote.Unvote(ctx, msg.PollID, connectionID, msg.Choice)
 	if err != nil {
-		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err)
+		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err, deps)
 	}
-	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID)
+	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID, deps)
 }
 
 // handlePollSwitch は投票変更メッセージを処理する。
-func (h *messageHandler) handlePollSwitch(ctx context.Context, connectionID string, msg incomingMessage) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) handlePollSwitch(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	if msg.PollID == "" || msg.From == "" || msg.To == "" {
-		return h.sendError(ctx, connectionID, "pollId, from, and to are required")
+		return h.sendError(ctx, connectionID, "pollId, from, and to are required", deps)
 	}
 	if msg.From == msg.To {
-		return h.sendError(ctx, connectionID, "from and to must be different")
+		return h.sendError(ctx, connectionID, "from and to must be different", deps)
 	}
 	err := h.pollSwitch.Switch(ctx, msg.PollID, connectionID, msg.From, msg.To)
 	if err != nil {
-		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err)
+		return h.handlePollError(ctx, connectionID, msg.PollID, connectionID, err, deps)
 	}
-	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID)
+	return h.refreshAndBroadcastPoll(ctx, msg.PollID, connectionID, deps)
 }
 
 // handlePollError はアンケート操作エラーを処理する。業務エラーは poll_error を送信元に返す。
 // ErrPollNotFound の場合は状態再取得をスキップしてエラーメッセージのみ返す。
-func (h *messageHandler) handlePollError(ctx context.Context, connectionID, pollID, visitorID string, err error) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) handlePollError(ctx context.Context, connectionID, pollID, visitorID string, err error, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	if !isPollBusinessError(err) {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("poll operation: %w", err)
 	}
 
 	if errors.Is(err, poll.ErrPollNotFound) {
-		return h.sendError(ctx, connectionID, err.Error())
+		return h.sendError(ctx, connectionID, err.Error(), deps)
 	}
 
 	state, getErr := h.pollGet.Get(ctx, pollID, visitorID, nil, 0, false)
@@ -297,7 +306,7 @@ func (h *messageHandler) handlePollError(ctx context.Context, connectionID, poll
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal poll_error: %w", marshalErr)
 	}
 
-	if sendErr := h.singleSender.SendToOne(ctx, room, connectionID, payload); sendErr != nil {
+	if sendErr := deps.singleSender.SendToOne(ctx, room, connectionID, payload); sendErr != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("send poll_error: %w", sendErr)
 	}
 
@@ -314,16 +323,16 @@ func isPollBusinessError(err error) bool {
 }
 
 // refreshAndBroadcastPoll は最新のアンケート状態を取得してブロードキャストする。
-func (h *messageHandler) refreshAndBroadcastPoll(ctx context.Context, pollID, visitorID string) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) refreshAndBroadcastPoll(ctx context.Context, pollID, visitorID string, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	state, err := h.pollGet.Get(ctx, pollID, visitorID, nil, 0, false)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("refresh poll state: %w", err)
 	}
-	return h.broadcastPollState(ctx, state)
+	return h.broadcastPollState(ctx, state, deps)
 }
 
 // sendPollState はアンケート状態を要求元の接続にのみ送信する。
-func (h *messageHandler) sendPollState(ctx context.Context, connectionID string, state *poll.PollState) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) sendPollState(ctx context.Context, connectionID string, state *poll.PollState, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	resp := pollStateResponse{
 		Type:       "poll_state",
 		PollID:     state.PollID,
@@ -337,7 +346,7 @@ func (h *messageHandler) sendPollState(ctx context.Context, connectionID string,
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal poll_state: %w", err)
 	}
 
-	if err := h.singleSender.SendToOne(ctx, room, connectionID, payload); err != nil {
+	if err := deps.singleSender.SendToOne(ctx, room, connectionID, payload); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("send poll_state: %w", err)
 	}
 
@@ -345,7 +354,7 @@ func (h *messageHandler) sendPollState(ctx context.Context, connectionID string,
 }
 
 // broadcastPollState はアンケート状態を全接続にブロードキャストする。
-func (h *messageHandler) broadcastPollState(ctx context.Context, state *poll.PollState) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) broadcastPollState(ctx context.Context, state *poll.PollState, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	resp := pollStateResponse{
 		Type:       "poll_state",
 		PollID:     state.PollID,
@@ -359,7 +368,7 @@ func (h *messageHandler) broadcastPollState(ctx context.Context, state *poll.Pol
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal poll_state: %w", err)
 	}
 
-	if err := h.broadcaster.Send(ctx, room, payload, ""); err != nil {
+	if err := deps.broadcaster.Send(ctx, room, payload, ""); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("broadcast poll_state: %w", err)
 	}
 
@@ -367,18 +376,23 @@ func (h *messageHandler) broadcastPollState(ctx context.Context, state *poll.Pol
 }
 
 // sendError はエラーレスポンスを送信元に返す。
-func (h *messageHandler) sendError(ctx context.Context, connectionID, errMsg string) (events.APIGatewayProxyResponse, error) {
+func (h *messageHandler) sendError(ctx context.Context, connectionID, errMsg string, deps handleDeps) (events.APIGatewayProxyResponse, error) {
 	resp := errorResponse{Type: "error", Error: errMsg}
 	payload, err := jsonMarshal(resp)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal error: %w", err)
 	}
 
-	if err := h.singleSender.SendToOne(ctx, room, connectionID, payload); err != nil {
+	if err := deps.singleSender.SendToOne(ctx, room, connectionID, payload); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("send error: %w", err)
 	}
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+// newAPIGWEndpoint は requestContext の domainName と stage からエンドポイント URL を構築する。
+func newAPIGWEndpoint(domainName, stage string) string {
+	return fmt.Sprintf("https://%s/%s", domainName, stage)
 }
 
 // run は依存を初期化し Lambda ハンドラーを起動する。
@@ -398,32 +412,30 @@ func run() error {
 	if pollTable == "" {
 		return fmt.Errorf("POLL_VOTES_TABLE environment variable is required")
 	}
-	apigwEndpoint := os.Getenv("APIGW_ENDPOINT")
-
-	apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
-		if apigwEndpoint != "" {
-			o.BaseEndpoint = &apigwEndpoint
-		}
-	})
 
 	connStore := connection.NewStore(ddbClient, connTable)
 	pollStore := poll.NewStore(ddbClient, pollTable)
-	b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
-	ssHandler := slidesync.NewHandler(connStore, b)
-	hoHandler := handson.NewHandler(connStore, b)
-	vcHandler := viewercount.NewHandler(connStore, &viewerCountAdapter{sender: b})
 
 	h := &messageHandler{
-		slideSync:    ssHandler,
-		handsOn:      hoHandler,
-		viewerCount:  vcHandler,
-		pollGet:      pollStore,
-		pollVote:     pollStore,
-		pollUnvote:   pollStore,
-		pollSwitch:   pollStore,
-		connGetter:   connStore,
-		broadcaster:  b,
-		singleSender: b,
+		pollGet:    pollStore,
+		pollVote:   pollStore,
+		pollUnvote: pollStore,
+		pollSwitch: pollStore,
+		connGetter: connStore,
+		newDeps: func(domainName, stage string) handleDeps {
+			endpoint := newAPIGWEndpoint(domainName, stage)
+			apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
+				o.BaseEndpoint = &endpoint
+			})
+			b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
+			return handleDeps{
+				slideSync:    slidesync.NewHandler(connStore, b),
+				handsOn:      handson.NewHandler(connStore, b),
+				viewerCount:  viewercount.NewHandler(connStore, &viewerCountAdapter{sender: b}),
+				broadcaster:  b,
+				singleSender: b,
+			}
+		},
 	}
 
 	startLambda(h.handle)

--- a/presenter/cmd/message/main.go
+++ b/presenter/cmd/message/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -395,6 +396,24 @@ func newAPIGWEndpoint(domainName, stage string) string {
 	return fmt.Sprintf("https://%s/%s", domainName, stage)
 }
 
+// newHandleDepsFactory は AWS 設定と接続ストアから handleDepsFactory を生成する。
+func newHandleDepsFactory(cfg aws.Config, connStore *connection.Store) handleDepsFactory {
+	return func(domainName, stage string) handleDeps {
+		endpoint := newAPIGWEndpoint(domainName, stage)
+		apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
+			o.BaseEndpoint = &endpoint
+		})
+		b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
+		return handleDeps{
+			slideSync:    slidesync.NewHandler(connStore, b),
+			handsOn:      handson.NewHandler(connStore, b),
+			viewerCount:  viewercount.NewHandler(connStore, &viewerCountAdapter{sender: b}),
+			broadcaster:  b,
+			singleSender: b,
+		}
+	}
+}
+
 // run は依存を初期化し Lambda ハンドラーを起動する。
 func run() error {
 	ctx := context.Background()
@@ -422,20 +441,7 @@ func run() error {
 		pollUnvote: pollStore,
 		pollSwitch: pollStore,
 		connGetter: connStore,
-		newDeps: func(domainName, stage string) handleDeps {
-			endpoint := newAPIGWEndpoint(domainName, stage)
-			apigwClient := apigatewaymanagementapi.NewFromConfig(cfg, func(o *apigatewaymanagementapi.Options) {
-				o.BaseEndpoint = &endpoint
-			})
-			b := broadcast.NewBroadcaster(apigwClient, connStore, connStore)
-			return handleDeps{
-				slideSync:    slidesync.NewHandler(connStore, b),
-				handsOn:      handson.NewHandler(connStore, b),
-				viewerCount:  viewercount.NewHandler(connStore, &viewerCountAdapter{sender: b}),
-				broadcaster:  b,
-				singleSender: b,
-			}
-		},
+		newDeps:    newHandleDepsFactory(cfg, connStore),
 	}
 
 	startLambda(h.handle)

--- a/presenter/cmd/message/main_test.go
+++ b/presenter/cmd/message/main_test.go
@@ -125,6 +125,40 @@ func newRequest(connectionID, body string) events.APIGatewayWebsocketProxyReques
 	}
 }
 
+// testHandlerOpts はテスト用 messageHandler 構築オプション。
+type testHandlerOpts struct {
+	slideSync    slideSyncDispatcher
+	handsOn      handsOnDispatcher
+	viewerCount  viewerCountDispatcher
+	pollGet      pollGetter
+	pollVote     pollVoter
+	pollUnvote   pollUnvoter
+	pollSwitch   pollSwitcher
+	connGetter   connectionGetter
+	broadcaster  messageBroadcaster
+	singleSender singleSender
+}
+
+// newTestHandler はテスト用の messageHandler を生成する。
+func newTestHandler(opts testHandlerOpts) *messageHandler {
+	return &messageHandler{
+		pollGet:    opts.pollGet,
+		pollVote:   opts.pollVote,
+		pollUnvote: opts.pollUnvote,
+		pollSwitch: opts.pollSwitch,
+		connGetter: opts.connGetter,
+		newDeps: func(_, _ string) handleDeps {
+			return handleDeps{
+				slideSync:    opts.slideSync,
+				handsOn:      opts.handsOn,
+				viewerCount:  opts.viewerCount,
+				broadcaster:  opts.broadcaster,
+				singleSender: opts.singleSender,
+			}
+		},
+	}
+}
+
 // defaultPollState はテスト用のデフォルト PollState を返す。
 func defaultPollState() *poll.PollState {
 	return &poll.PollState{
@@ -140,14 +174,14 @@ func defaultPollState() *poll.PollState {
 func TestHandle_SlideSync(t *testing.T) {
 	t.Parallel()
 	var capturedPage int
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		slideSync: &mockSlideSyncDispatcher{
 			handleFn: func(_ context.Context, _, _ string, page int) error {
 				capturedPage = page
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"slide_sync","page":3}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -165,7 +199,7 @@ func TestHandle_SlideSync(t *testing.T) {
 func TestHandle_SlideSyncError(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		slideSync: &mockSlideSyncDispatcher{
 			handleFn: func(_ context.Context, _, _ string, _ int) error {
 				return fmt.Errorf("not presenter")
@@ -177,7 +211,7 @@ func TestHandle_SlideSyncError(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"slide_sync","page":1}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -199,7 +233,7 @@ func TestHandle_SlideSyncError(t *testing.T) {
 func TestHandle_HandsOn(t *testing.T) {
 	t.Parallel()
 	var capturedRoom, capturedConnID, capturedInstruction, capturedPlaceholder string
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		handsOn: &mockHandsOnDispatcher{
 			handleFn: func(_ context.Context, room, connectionID, instruction, placeholder string) error {
 				capturedRoom = room
@@ -209,7 +243,7 @@ func TestHandle_HandsOn(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"hands_on","instruction":"Write hello world","placeholder":"your code here"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -236,7 +270,7 @@ func TestHandle_HandsOn(t *testing.T) {
 func TestHandle_HandsOnError(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		handsOn: &mockHandsOnDispatcher{
 			handleFn: func(_ context.Context, _, _, _, _ string) error {
 				return fmt.Errorf("not presenter")
@@ -248,7 +282,7 @@ func TestHandle_HandsOnError(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"hands_on","instruction":"test","placeholder":"test"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -270,14 +304,14 @@ func TestHandle_HandsOnError(t *testing.T) {
 func TestHandle_ViewerCount(t *testing.T) {
 	t.Parallel()
 	called := false
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		viewerCount: &mockViewerCountDispatcher{
 			handleFn: func(_ context.Context, _, _ string) error {
 				called = true
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"viewer_count"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -294,13 +328,13 @@ func TestHandle_ViewerCount(t *testing.T) {
 // TestHandle_ViewerCountError は接続数通知エラーを検証する。
 func TestHandle_ViewerCountError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		viewerCount: &mockViewerCountDispatcher{
 			handleFn: func(_ context.Context, _, _ string) error {
 				return fmt.Errorf("count error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"viewer_count"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -312,7 +346,7 @@ func TestHandle_ViewerCountError(t *testing.T) {
 func TestHandle_PollGet(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "presenter"}, nil
@@ -332,7 +366,7 @@ func TestHandle_PollGet(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1","options":["A","B"],"maxChoices":1}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -353,7 +387,7 @@ func TestHandle_PollGet(t *testing.T) {
 // TestHandle_PollGetViewer はビューアーからのアンケート取得を検証する。
 func TestHandle_PollGetViewer(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "viewer"}, nil
@@ -372,7 +406,7 @@ func TestHandle_PollGetViewer(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -386,13 +420,13 @@ func TestHandle_PollGetViewer(t *testing.T) {
 // TestHandle_PollGetConnError は接続情報取得エラーを検証する。
 func TestHandle_PollGetConnError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return nil, fmt.Errorf("conn error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -403,7 +437,7 @@ func TestHandle_PollGetConnError(t *testing.T) {
 // TestHandle_PollGetError はアンケート取得の内部エラーを検証する。
 func TestHandle_PollGetError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "viewer"}, nil
@@ -414,7 +448,7 @@ func TestHandle_PollGetError(t *testing.T) {
 				return nil, fmt.Errorf("get error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1","visitorId":"v1"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -426,7 +460,7 @@ func TestHandle_PollGetError(t *testing.T) {
 func TestHandle_PollGetNotFound(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "viewer"}, nil
@@ -443,7 +477,7 @@ func TestHandle_PollGetNotFound(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -468,7 +502,7 @@ func TestHandle_PollGetNotFound(t *testing.T) {
 func TestHandle_PollVoteInvalidChoice(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrInvalidChoice
@@ -485,7 +519,7 @@ func TestHandle_PollVoteInvalidChoice(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","choice":"C"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -507,7 +541,7 @@ func TestHandle_PollVoteInvalidChoice(t *testing.T) {
 func TestHandle_PollVotePollNotFound(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrPollNotFound
@@ -519,7 +553,7 @@ func TestHandle_PollVotePollNotFound(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","choice":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -544,7 +578,7 @@ func TestHandle_PollVotePollNotFound(t *testing.T) {
 func TestHandle_PollSwitchInvalidChoice(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollSwitch: &mockPollSwitcher{
 			switchFn: func(_ context.Context, _, _, _, _ string) error {
 				return poll.ErrInvalidChoice
@@ -561,7 +595,7 @@ func TestHandle_PollSwitchInvalidChoice(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","from":"A","to":"C"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -583,7 +617,7 @@ func TestHandle_PollSwitchInvalidChoice(t *testing.T) {
 func TestHandle_PollVote(t *testing.T) {
 	t.Parallel()
 	var broadcastCalled bool
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return nil
@@ -600,7 +634,7 @@ func TestHandle_PollVote(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -618,7 +652,7 @@ func TestHandle_PollVote(t *testing.T) {
 func TestHandle_PollVoteDuplicate(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrDuplicateVote
@@ -635,7 +669,7 @@ func TestHandle_PollVoteDuplicate(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -656,7 +690,7 @@ func TestHandle_PollVoteDuplicate(t *testing.T) {
 // TestHandle_PollVoteMaxExceeded は最大選択数超過時の poll_error レスポンスを検証する。
 func TestHandle_PollVoteMaxExceeded(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrMaxChoicesExceeded
@@ -672,7 +706,7 @@ func TestHandle_PollVoteMaxExceeded(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"C"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -686,13 +720,13 @@ func TestHandle_PollVoteMaxExceeded(t *testing.T) {
 // TestHandle_PollVoteInternalError は投票の内部エラーを検証する。
 func TestHandle_PollVoteInternalError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return fmt.Errorf("internal error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -703,7 +737,7 @@ func TestHandle_PollVoteInternalError(t *testing.T) {
 // TestHandle_PollUnvote は投票取消の正常処理を検証する。
 func TestHandle_PollUnvote(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollUnvote: &mockPollUnvoter{
 			unvoteFn: func(_ context.Context, _, _, _ string) error {
 				return nil
@@ -719,7 +753,7 @@ func TestHandle_PollUnvote(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_unvote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -733,7 +767,7 @@ func TestHandle_PollUnvote(t *testing.T) {
 // TestHandle_PollUnvoteNotFound は投票取消の ErrVoteNotFound を検証する。
 func TestHandle_PollUnvoteNotFound(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollUnvote: &mockPollUnvoter{
 			unvoteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrVoteNotFound
@@ -749,7 +783,7 @@ func TestHandle_PollUnvoteNotFound(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_unvote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -763,13 +797,13 @@ func TestHandle_PollUnvoteNotFound(t *testing.T) {
 // TestHandle_PollUnvoteInternalError は投票取消の内部エラーを検証する。
 func TestHandle_PollUnvoteInternalError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollUnvote: &mockPollUnvoter{
 			unvoteFn: func(_ context.Context, _, _, _ string) error {
 				return fmt.Errorf("internal error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_unvote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -780,7 +814,7 @@ func TestHandle_PollUnvoteInternalError(t *testing.T) {
 // TestHandle_PollSwitch は投票変更の正常処理を検証する。
 func TestHandle_PollSwitch(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollSwitch: &mockPollSwitcher{
 			switchFn: func(_ context.Context, _, _, _, _ string) error {
 				return nil
@@ -796,7 +830,7 @@ func TestHandle_PollSwitch(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","visitorId":"v1","from":"A","to":"B"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -810,7 +844,7 @@ func TestHandle_PollSwitch(t *testing.T) {
 // TestHandle_PollSwitchVoteNotFound は投票変更の ErrVoteNotFound を検証する。
 func TestHandle_PollSwitchVoteNotFound(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollSwitch: &mockPollSwitcher{
 			switchFn: func(_ context.Context, _, _, _, _ string) error {
 				return poll.ErrVoteNotFound
@@ -826,7 +860,7 @@ func TestHandle_PollSwitchVoteNotFound(t *testing.T) {
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","visitorId":"v1","from":"A","to":"B"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -840,13 +874,13 @@ func TestHandle_PollSwitchVoteNotFound(t *testing.T) {
 // TestHandle_PollSwitchInternalError は投票変更の内部エラーを検証する。
 func TestHandle_PollSwitchInternalError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollSwitch: &mockPollSwitcher{
 			switchFn: func(_ context.Context, _, _, _, _ string) error {
 				return fmt.Errorf("internal error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","visitorId":"v1","from":"A","to":"B"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -858,14 +892,14 @@ func TestHandle_PollSwitchInternalError(t *testing.T) {
 func TestHandle_UnknownType(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"unknown"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -886,7 +920,7 @@ func TestHandle_UnknownType(t *testing.T) {
 // TestHandle_InvalidJSON は不正 JSON のエラーを検証する。
 func TestHandle_InvalidJSON(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{}
+	h := newTestHandler(testHandlerOpts{})
 	req := newRequest("conn1", `invalid json`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -897,7 +931,7 @@ func TestHandle_InvalidJSON(t *testing.T) {
 // TestHandle_PollVoteRefreshError は投票後の状態取得エラーを検証する。
 func TestHandle_PollVoteRefreshError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return nil
@@ -908,7 +942,7 @@ func TestHandle_PollVoteRefreshError(t *testing.T) {
 				return nil, fmt.Errorf("get error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -919,7 +953,7 @@ func TestHandle_PollVoteRefreshError(t *testing.T) {
 // TestHandle_PollVoteBroadcastError は投票後のブロードキャストエラーを検証する。
 func TestHandle_PollVoteBroadcastError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return nil
@@ -935,7 +969,7 @@ func TestHandle_PollVoteBroadcastError(t *testing.T) {
 				return fmt.Errorf("broadcast error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -946,7 +980,7 @@ func TestHandle_PollVoteBroadcastError(t *testing.T) {
 // TestHandle_PollErrorGetStateError は業務エラー後の状態取得失敗を検証する。
 func TestHandle_PollErrorGetStateError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrDuplicateVote
@@ -957,7 +991,7 @@ func TestHandle_PollErrorGetStateError(t *testing.T) {
 				return nil, fmt.Errorf("get error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -968,7 +1002,7 @@ func TestHandle_PollErrorGetStateError(t *testing.T) {
 // TestHandle_PollErrorSendError は poll_error 送信失敗を検証する。
 func TestHandle_PollErrorSendError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrDuplicateVote
@@ -984,7 +1018,7 @@ func TestHandle_PollErrorSendError(t *testing.T) {
 				return fmt.Errorf("send error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1000,13 +1034,13 @@ func TestHandle_SendErrorMarshalError(t *testing.T) {
 	jsonMarshal = func(_ any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal error")
 	}
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		slideSync: &mockSlideSyncDispatcher{
 			handleFn: func(_ context.Context, _, _ string, _ int) error {
 				return fmt.Errorf("slide error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"slide_sync","page":1}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1022,7 +1056,7 @@ func TestHandle_PollErrorMarshalError(t *testing.T) {
 	jsonMarshal = func(_ any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal error")
 	}
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return poll.ErrDuplicateVote
@@ -1033,7 +1067,7 @@ func TestHandle_PollErrorMarshalError(t *testing.T) {
 				return defaultPollState(), nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1049,7 +1083,7 @@ func TestHandle_PollGetMarshalError(t *testing.T) {
 	jsonMarshal = func(_ any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal error")
 	}
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "viewer"}, nil
@@ -1060,7 +1094,7 @@ func TestHandle_PollGetMarshalError(t *testing.T) {
 				return defaultPollState(), nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1076,7 +1110,7 @@ func TestHandle_PollStateMarshalError(t *testing.T) {
 	jsonMarshal = func(_ any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal error")
 	}
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		pollVote: &mockPollVoter{
 			voteFn: func(_ context.Context, _, _, _ string) error {
 				return nil
@@ -1087,7 +1121,7 @@ func TestHandle_PollStateMarshalError(t *testing.T) {
 				return defaultPollState(), nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1","visitorId":"v1","choice":"A"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1098,7 +1132,7 @@ func TestHandle_PollStateMarshalError(t *testing.T) {
 // TestHandle_SendErrorSendToOneError はエラーレスポンスの SendToOne 失敗を検証する。
 func TestHandle_SendErrorSendToOneError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		slideSync: &mockSlideSyncDispatcher{
 			handleFn: func(_ context.Context, _, _ string, _ int) error {
 				return fmt.Errorf("slide error")
@@ -1109,7 +1143,7 @@ func TestHandle_SendErrorSendToOneError(t *testing.T) {
 				return fmt.Errorf("send error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"slide_sync","page":1}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1120,7 +1154,7 @@ func TestHandle_SendErrorSendToOneError(t *testing.T) {
 // TestHandle_PollGetSendError はアンケート取得後の送信エラーを検証する。
 func TestHandle_PollGetSendError(t *testing.T) {
 	t.Parallel()
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		connGetter: &mockConnectionGetter{
 			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
 				return &connection.Connection{Role: "viewer"}, nil
@@ -1136,7 +1170,7 @@ func TestHandle_PollGetSendError(t *testing.T) {
 				return fmt.Errorf("send error")
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get","pollId":"q1"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
@@ -1185,15 +1219,14 @@ func TestRun_Success(t *testing.T) {
 
 	t.Setenv("CONNECTIONS_TABLE", "conn-table")
 	t.Setenv("POLL_VOTES_TABLE", "poll-table")
-	t.Setenv("APIGW_ENDPOINT", "")
 
 	if err := run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-// TestRun_SuccessWithEndpoint は APIGW_ENDPOINT 設定時の run 関数を検証する。
-func TestRun_SuccessWithEndpoint(t *testing.T) {
+// TestRun_DepsFactory は run で生成される newDeps が依存を返すことを検証する。
+func TestRun_DepsFactory(t *testing.T) {
 	origLoadConfig := loadConfig
 	origStartLambda := startLambda
 	defer func() {
@@ -1204,14 +1237,36 @@ func TestRun_SuccessWithEndpoint(t *testing.T) {
 	loadConfig = func(_ context.Context, _ ...func(*config.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, nil
 	}
-	startLambda = func(_ interface{}) {}
 
 	t.Setenv("CONNECTIONS_TABLE", "conn-table")
 	t.Setenv("POLL_VOTES_TABLE", "poll-table")
-	t.Setenv("APIGW_ENDPOINT", "https://example.com")
+
+	var capturedHandler any
+	startLambda = func(handler any) { capturedHandler = handler }
 
 	if err := run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handlerFn := capturedHandler.(func(context.Context, events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error))
+	req := events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+			ConnectionID: "test-conn",
+			DomainName:   "test.execute-api.ap-northeast-1.amazonaws.com",
+			Stage:        "ws",
+		},
+		Body: `{"type":"viewer_count"}`,
+	}
+	_, _ = handlerFn(context.Background(), req)
+}
+
+// TestNewAPIGWEndpoint は requestContext からエンドポイント URL を構築することを検証する。
+func TestNewAPIGWEndpoint(t *testing.T) {
+	t.Parallel()
+	got := newAPIGWEndpoint("abc123.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	expected := "https://abc123.execute-api.ap-northeast-1.amazonaws.com/ws"
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
 	}
 }
 
@@ -1286,14 +1341,14 @@ func TestViewerCountAdapter_SendToOneError(t *testing.T) {
 func TestHandlePollGet_MissingPollID(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_get"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -1311,14 +1366,14 @@ func TestHandlePollGet_MissingPollID(t *testing.T) {
 func TestHandlePollVote_MissingFields(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_vote","pollId":"q1"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -1336,14 +1391,14 @@ func TestHandlePollVote_MissingFields(t *testing.T) {
 func TestHandlePollUnvote_MissingFields(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_unvote","pollId":"q1"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -1361,14 +1416,14 @@ func TestHandlePollUnvote_MissingFields(t *testing.T) {
 func TestHandlePollSwitch_MissingFields(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","from":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {
@@ -1386,14 +1441,14 @@ func TestHandlePollSwitch_MissingFields(t *testing.T) {
 func TestHandlePollSwitch_FromEqualsTo(t *testing.T) {
 	t.Parallel()
 	var sentPayload []byte
-	h := &messageHandler{
+	h := newTestHandler(testHandlerOpts{
 		singleSender: &mockSingleSender{
 			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
 				sentPayload = payload
 				return nil
 			},
 		},
-	}
+	})
 	req := newRequest("conn1", `{"type":"poll_switch","pollId":"q1","from":"A","to":"A"}`)
 	resp, err := h.handle(context.Background(), req)
 	if err != nil {

--- a/presenter/cmd/message/main_test.go
+++ b/presenter/cmd/message/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
 	"github.com/ogadra/20260327-cli-demo/presenter/internal/connection"
 	"github.com/ogadra/20260327-cli-demo/presenter/internal/poll"
@@ -1247,17 +1248,33 @@ func TestRun_DepsFactory(t *testing.T) {
 	if err := run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	handlerFn := capturedHandler.(func(context.Context, events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error))
-	req := events.APIGatewayWebsocketProxyRequest{
-		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
-			ConnectionID: "test-conn",
-			DomainName:   "test.execute-api.ap-northeast-1.amazonaws.com",
-			Stage:        "ws",
-		},
-		Body: `{"type":"viewer_count"}`,
+	if capturedHandler == nil {
+		t.Fatal("expected handler to be registered")
 	}
-	_, _ = handlerFn(context.Background(), req)
+}
+
+// TestNewHandleDepsFactory は newHandleDepsFactory が依存を返すことを検証する。
+func TestNewHandleDepsFactory(t *testing.T) {
+	t.Parallel()
+	cfg := aws.Config{}
+	connStore := connection.NewStore(dynamodb.NewFromConfig(cfg), "test-table")
+	factory := newHandleDepsFactory(cfg, connStore)
+	deps := factory("example.execute-api.ap-northeast-1.amazonaws.com", "ws")
+	if deps.slideSync == nil {
+		t.Fatal("expected slideSync to be non-nil")
+	}
+	if deps.handsOn == nil {
+		t.Fatal("expected handsOn to be non-nil")
+	}
+	if deps.viewerCount == nil {
+		t.Fatal("expected viewerCount to be non-nil")
+	}
+	if deps.broadcaster == nil {
+		t.Fatal("expected broadcaster to be non-nil")
+	}
+	if deps.singleSender == nil {
+		t.Fatal("expected singleSender to be non-nil")
+	}
 }
 
 // TestNewAPIGWEndpoint は requestContext からエンドポイント URL を構築することを検証する。

--- a/terraform/presenter_lambda.tf
+++ b/terraform/presenter_lambda.tf
@@ -60,10 +60,9 @@ resource "aws_lambda_function" "presenter_ws" {
 
   environment {
     variables = {
-      WS_CONNECTIONS_TABLE   = aws_dynamodb_table.presenter_ws_connections.name
-      SESSIONS_TABLE         = aws_dynamodb_table.presenter_sessions.name
-      POLL_VOTES_TABLE       = aws_dynamodb_table.presenter_poll_votes.name
-      WEBSOCKET_API_ENDPOINT = "${aws_apigatewayv2_api.presenter_websocket.id}.execute-api.${data.aws_region.current.id}.amazonaws.com/${aws_apigatewayv2_stage.presenter_websocket.name}"
+      CONNECTIONS_TABLE = aws_dynamodb_table.presenter_ws_connections.name
+      SESSIONS_TABLE    = aws_dynamodb_table.presenter_sessions.name
+      POLL_VOTES_TABLE  = aws_dynamodb_table.presenter_poll_votes.name
     }
   }
 


### PR DESCRIPTION
## Summary
- `WS_CONNECTIONS_TABLE` → `CONNECTIONS_TABLE` to match what the Lambda code expects via `os.Getenv("CONNECTIONS_TABLE")`
- Removed unused `WEBSOCKET_API_ENDPOINT` env var from Terraform
- Derive API Gateway Management API endpoint from `requestContext.DomainName` and `Stage` at runtime, matching the Python implementation in 20260220-lambda-demo
- `APIGW_ENDPOINT` environment variable is no longer needed

The env var mismatch caused the Lambda to crash at startup with `"CONNECTIONS_TABLE environment variable is required"`, resulting in 502 Bad Gateway on WebSocket connect. The missing endpoint caused `PostToConnection` to fail with DNS resolution error.

## Test plan
- [x] `docker build --target test presenter/` passes with 100% coverage
- [ ] `terraform plan` で差分確認
- [ ] `terraform apply` 後に Lambda 再デプロイ
- [ ] `/presenter` ページで WebSocket 接続が成功し viewer_count が配信されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * WebSocketハンドラーの内部実装を最適化し、API Gatewayエンドポイントの計算をリクエスト処理時に移行しました。
  * 環境設定を簡素化するため、不要な環境変数を削除しました。
  * テストスイートを拡充し、新しい動的な処理フロー検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->