### PR TITLE
fix: add missing SG rules for broker-to-runner healthcheck

### DIFF
--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -131,6 +131,18 @@ resource "aws_security_group_rule" "broker_ingress_runner" {
   description              = "HTTP from runner"
 }
 
+# broker outbound: to runner (healthcheck)
+resource "aws_security_group_rule" "broker_egress_runner" {
+  # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
+  type                     = "egress"
+  from_port                = local.ecs_services["runner"].port
+  to_port                  = local.ecs_services["runner"].port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.runner.id
+  security_group_id        = aws_security_group.broker.id
+  description              = "HTTP to runner for healthcheck"
+}
+
 # broker outbound: to DynamoDB VPC endpoint
 resource "aws_security_group_rule" "broker_egress_dynamodb" {
   # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
@@ -168,6 +180,18 @@ resource "aws_security_group_rule" "runner_ingress_nginx" {
   source_security_group_id = aws_security_group.nginx.id
   security_group_id        = aws_security_group.runner.id
   description              = "HTTP from nginx"
+}
+
+# runner inbound: from broker (healthcheck)
+resource "aws_security_group_rule" "runner_ingress_broker" {
+  # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
+  type                     = "ingress"
+  from_port                = local.ecs_services["runner"].port
+  to_port                  = local.ecs_services["runner"].port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.broker.id
+  security_group_id        = aws_security_group.runner.id
+  description              = "HTTP from broker for healthcheck"
 }
 
 # runner outbound: to broker


### PR DESCRIPTION
## Summary
- Broker was unable to reach runners for healthcheck due to missing security group rules
- All runners were being marked as stale and deleted, causing `/resolve` to return 503
- Nginx's `auth_request` then converted the 503 into a 500 on `POST /api/session`
- Added `broker_egress_runner` (broker → runner egress) and `runner_ingress_broker` (runner ← broker ingress) SG rules

## Test plan
- [ ] `terraform plan` confirms only 2 new SG rules are added
- [ ] `terraform apply` and verify broker healthcheck logs no longer show failures
- [ ] Verify `POST /api/session` returns 204 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ブローカーとランナーコンポーネント間のヘルスチェックトラフィックを許可するセキュリティグループルールを追加しました。ブローカーからランナーへのアウトバウンドトラフィックと、ランナーからのインバウンドトラフィックを新たに許可します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->