### PR TITLE
feat: make presenter buttons full-width for mobile

### DIFF
--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -130,7 +130,12 @@ export const PresenterPanel = ({
         {describeStep(currentStep)}
       </div>
 
-      <div style={{ display: "flex" }}>
+      <div
+        style={{
+          display: "flex",
+          paddingBottom: "env(safe-area-inset-bottom)",
+        }}
+      >
         <button
           type="button"
           disabled={stepIndex === 0}

--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -141,6 +141,7 @@ export const PresenterPanel = ({
             background: stepIndex === 0 ? "#333" : "#555",
             color: stepIndex === 0 ? "#666" : "#fff",
             border: "none",
+            borderRadius: "4px",
             cursor: stepIndex === 0 ? "not-allowed" : "pointer",
             fontSize: "20px",
           }}
@@ -157,6 +158,7 @@ export const PresenterPanel = ({
             background: stepIndex === sequence.length - 1 ? "#333" : "#555",
             color: stepIndex === sequence.length - 1 ? "#666" : "#fff",
             border: "none",
+            borderRadius: "4px",
             cursor: stepIndex === sequence.length - 1 ? "not-allowed" : "pointer",
             fontSize: "20px",
           }}

--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -95,9 +95,10 @@ export const PresenterPanel = ({
       style={{
         background: "#1a1a1a",
         color: "#fff",
-        padding: "24px",
         fontFamily: "sans-serif",
-        minHeight: "100vh",
+        height: "100dvh",
+        display: "flex",
+        flexDirection: "column",
       }}
     >
       <header
@@ -105,7 +106,7 @@ export const PresenterPanel = ({
         style={{
           display: "flex",
           justifyContent: "space-between",
-          marginBottom: "24px",
+          padding: "16px 24px",
           fontSize: "14px",
           color: "#aaa",
         }}
@@ -116,21 +117,32 @@ export const PresenterPanel = ({
         <span>{viewerCount} viewers</span>
       </header>
 
-      <div style={{ fontSize: "20px", marginBottom: "24px" }}>{describeStep(currentStep)}</div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "20px",
+          padding: "0 24px",
+        }}
+      >
+        {describeStep(currentStep)}
+      </div>
 
-      <div style={{ display: "flex", gap: "12px" }}>
+      <div style={{ display: "flex" }}>
         <button
           type="button"
           disabled={stepIndex === 0}
           onClick={(): void => goTo(stepIndex - 1)}
           style={{
-            padding: "8px 24px",
+            flex: 1,
+            padding: "32px 0",
             background: stepIndex === 0 ? "#333" : "#555",
             color: stepIndex === 0 ? "#666" : "#fff",
             border: "none",
-            borderRadius: "4px",
             cursor: stepIndex === 0 ? "not-allowed" : "pointer",
-            fontSize: "16px",
+            fontSize: "20px",
           }}
         >
           Prev
@@ -140,13 +152,13 @@ export const PresenterPanel = ({
           disabled={stepIndex === sequence.length - 1}
           onClick={(): void => goTo(stepIndex + 1)}
           style={{
-            padding: "8px 24px",
+            flex: 1,
+            padding: "32px 0",
             background: stepIndex === sequence.length - 1 ? "#333" : "#555",
             color: stepIndex === sequence.length - 1 ? "#666" : "#fff",
             border: "none",
-            borderRadius: "4px",
             cursor: stepIndex === sequence.length - 1 ? "not-allowed" : "pointer",
-            fontSize: "16px",
+            fontSize: "20px",
           }}
         >
           Next


### PR DESCRIPTION
## Summary
- Prev/Next buttons stretch to full screen width with `flex: 1` and `borderRadius: 4px`
- Large touch targets (`padding: 32px`, `fontSize: 20px`) for blind operation on smartphones
- Buttons pinned to bottom of viewport using flexbox column layout with safe-area inset
- Step description centered vertically in remaining space

## Test plan
- [x] `pnpm vp test` — 154 tests pass
- [ ] Open `/presenter` on mobile and verify buttons fill the screen width

🤖 Generated with [Claude Code](https://claude.com/claude-code)