### PR TITLE
feat: add get_state message to return current slide position

### DIFF
--- a/presenter/cmd/message/main.go
+++ b/presenter/cmd/message/main.go
@@ -115,14 +115,21 @@ type handleDeps struct {
 	singleSender singleSender
 }
 
+// stateReader は room の現在のスライドページを取得するインターフェース。
+type stateReader interface {
+	// GetState は room の現在のスライドページを取得する。
+	GetState(ctx context.Context, room string) (int, error)
+}
+
 // messageHandler は $default イベントを処理するハンドラー。
 type messageHandler struct {
-	pollGet    pollGetter
-	pollVote   pollVoter
-	pollUnvote pollUnvoter
-	pollSwitch pollSwitcher
-	connGetter connectionGetter
-	newDeps    handleDepsFactory
+	pollGet     pollGetter
+	pollVote    pollVoter
+	pollUnvote  pollUnvoter
+	pollSwitch  pollSwitcher
+	connGetter  connectionGetter
+	stateReader stateReader
+	newDeps     handleDepsFactory
 }
 
 // incomingMessage はクライアントからの受信メッセージ。
@@ -181,6 +188,8 @@ func (h *messageHandler) handle(ctx context.Context, req events.APIGatewayWebsoc
 		return h.handleHandsOn(ctx, connectionID, msg, deps)
 	case "viewer_count":
 		return h.handleViewerCount(ctx, connectionID, deps)
+	case "get_state":
+		return h.handleGetState(ctx, connectionID, deps)
 	case "poll_get":
 		return h.handlePollGet(ctx, connectionID, msg, deps)
 	case "poll_vote":
@@ -215,6 +224,32 @@ func (h *messageHandler) handleViewerCount(ctx context.Context, connectionID str
 	if err := deps.viewerCount.Handle(ctx, room, connectionID); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("viewer_count: %w", err)
 	}
+	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+// slideSyncResponse はスライド同期レスポンス。
+type slideSyncResponse struct {
+	Type string `json:"type"`
+	Page int    `json:"page"`
+}
+
+// handleGetState は現在のスライド位置を送信元に返す。
+func (h *messageHandler) handleGetState(ctx context.Context, connectionID string, deps handleDeps) (events.APIGatewayProxyResponse, error) {
+	page, err := h.stateReader.GetState(ctx, room)
+	if err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("get state: %w", err)
+	}
+
+	resp := slideSyncResponse{Type: "slide_sync", Page: page}
+	payload, err := jsonMarshal(resp)
+	if err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("marshal slide_sync: %w", err)
+	}
+
+	if err := deps.singleSender.SendToOne(ctx, room, connectionID, payload); err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("send slide_sync: %w", err)
+	}
+
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
 
@@ -443,12 +478,13 @@ func run() error {
 	stateStore := roomstate.NewStore(ddbClient, stateTable)
 
 	h := &messageHandler{
-		pollGet:    pollStore,
-		pollVote:   pollStore,
-		pollUnvote: pollStore,
-		pollSwitch: pollStore,
-		connGetter: connStore,
-		newDeps:    newHandleDepsFactory(cfg, connStore, stateStore),
+		pollGet:     pollStore,
+		pollVote:    pollStore,
+		pollUnvote:  pollStore,
+		pollSwitch:  pollStore,
+		connGetter:  connStore,
+		stateReader: stateStore,
+		newDeps:     newHandleDepsFactory(cfg, connStore, stateStore),
 	}
 
 	startLambda(h.handle)

--- a/presenter/cmd/message/main_test.go
+++ b/presenter/cmd/message/main_test.go
@@ -127,6 +127,16 @@ func newRequest(connectionID, body string) events.APIGatewayWebsocketProxyReques
 	}
 }
 
+// mockStateReader は stateReader のモック。
+type mockStateReader struct {
+	getStateFn func(ctx context.Context, room string) (int, error)
+}
+
+// GetState はモックの GetState を呼び出す。
+func (m *mockStateReader) GetState(ctx context.Context, room string) (int, error) {
+	return m.getStateFn(ctx, room)
+}
+
 // testHandlerOpts はテスト用 messageHandler 構築オプション。
 type testHandlerOpts struct {
 	slideSync    slideSyncDispatcher
@@ -137,6 +147,7 @@ type testHandlerOpts struct {
 	pollUnvote   pollUnvoter
 	pollSwitch   pollSwitcher
 	connGetter   connectionGetter
+	stateReader  stateReader
 	broadcaster  messageBroadcaster
 	singleSender singleSender
 }
@@ -144,11 +155,12 @@ type testHandlerOpts struct {
 // newTestHandler はテスト用の messageHandler を生成する。
 func newTestHandler(opts testHandlerOpts) *messageHandler {
 	return &messageHandler{
-		pollGet:    opts.pollGet,
-		pollVote:   opts.pollVote,
-		pollUnvote: opts.pollUnvote,
-		pollSwitch: opts.pollSwitch,
-		connGetter: opts.connGetter,
+		pollGet:     opts.pollGet,
+		pollVote:    opts.pollVote,
+		pollUnvote:  opts.pollUnvote,
+		pollSwitch:  opts.pollSwitch,
+		connGetter:  opts.connGetter,
+		stateReader: opts.stateReader,
 		newDeps: func(_, _ string) handleDeps {
 			return handleDeps{
 				slideSync:    opts.slideSync,
@@ -338,6 +350,98 @@ func TestHandle_ViewerCountError(t *testing.T) {
 		},
 	})
 	req := newRequest("conn1", `{"type":"viewer_count"}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestHandle_GetState は現在のスライド位置を返す正常処理を検証する。
+func TestHandle_GetState(t *testing.T) {
+	t.Parallel()
+	var sentPayload []byte
+	h := newTestHandler(testHandlerOpts{
+		stateReader: &mockStateReader{
+			getStateFn: func(_ context.Context, _ string) (int, error) {
+				return 5, nil
+			},
+		},
+		singleSender: &mockSingleSender{
+			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
+				sentPayload = payload
+				return nil
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"get_state"}`)
+	resp, err := h.handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	expected := `{"type":"slide_sync","page":5}`
+	if string(sentPayload) != expected {
+		t.Errorf("expected %s, got %s", expected, string(sentPayload))
+	}
+}
+
+// TestHandle_GetStateError は状態取得エラーを検証する。
+func TestHandle_GetStateError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(testHandlerOpts{
+		stateReader: &mockStateReader{
+			getStateFn: func(_ context.Context, _ string) (int, error) {
+				return 0, fmt.Errorf("state error")
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"get_state"}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestHandle_GetStateSendError は状態送信エラーを検証する。
+func TestHandle_GetStateSendError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(testHandlerOpts{
+		stateReader: &mockStateReader{
+			getStateFn: func(_ context.Context, _ string) (int, error) {
+				return 0, nil
+			},
+		},
+		singleSender: &mockSingleSender{
+			sendToOneFn: func(_ context.Context, _, _ string, _ []byte) error {
+				return fmt.Errorf("send error")
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"get_state"}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestHandle_GetStateMarshalError は状態 marshal エラーを検証する。
+// jsonMarshal を差し替えるため非 parallel。
+func TestHandle_GetStateMarshalError(t *testing.T) {
+	orig := jsonMarshal
+	defer func() { jsonMarshal = orig }()
+	jsonMarshal = func(_ any) ([]byte, error) {
+		return nil, fmt.Errorf("marshal error")
+	}
+	h := newTestHandler(testHandlerOpts{
+		stateReader: &mockStateReader{
+			getStateFn: func(_ context.Context, _ string) (int, error) {
+				return 0, nil
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"get_state"}`)
 	_, err := h.handle(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error")

--- a/presenter/internal/slidesync/slidesync.go
+++ b/presenter/internal/slidesync/slidesync.go
@@ -70,12 +70,12 @@ func (h *Handler) Handle(ctx context.Context, room, connectionID string, page in
 		return fmt.Errorf("marshal slide_sync: %w", err)
 	}
 
-	if err := h.broadcaster.Send(ctx, room, payload, connectionID); err != nil {
-		return fmt.Errorf("broadcast slide_sync: %w", err)
-	}
-
 	if err := h.stateWriter.PutState(ctx, room, page); err != nil {
 		return fmt.Errorf("save state: %w", err)
+	}
+
+	if err := h.broadcaster.Send(ctx, room, payload, connectionID); err != nil {
+		return fmt.Errorf("broadcast slide_sync: %w", err)
 	}
 
 	return nil

--- a/presenter/internal/slidesync/slidesync_test.go
+++ b/presenter/internal/slidesync/slidesync_test.go
@@ -172,7 +172,11 @@ func TestHandle_BroadcastError(t *testing.T) {
 				return fmt.Errorf("broadcast error")
 			},
 		},
-		&mockStateWriter{},
+		&mockStateWriter{
+			putStateFn: func(_ context.Context, _ string, _ int) error {
+				return nil
+			},
+		},
 	)
 	err := h.Handle(context.Background(), "default", "conn1", 3)
 	if err == nil {


### PR DESCRIPTION
## Summary
- Add `get_state` message type to the `$default` WebSocket handler
- Viewers send `{"type":"get_state"}` after connecting to receive the current slide position
- Server responds with `{"type":"slide_sync","page":N}` using the state persisted in PR #8
- This enables late-joining viewers to start at the correct slide

## Test plan
- [x] `docker build --target test presenter/` — 100% coverage
- [ ] Deploy, open viewer after presenter has advanced slides, verify correct initial position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ルーム状態のリクエスト機能を追加。現在のスライドページ情報が取得できるようになりました。

* **テスト**
  * 新機能の包括的なテストを追加。正常系やエラー系など複数のシナリオに対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->