### PR TITLE
feat: vertical scroll layout for viewer with initial position sync

### DIFF
--- a/front/src/App.test.tsx
+++ b/front/src/App.test.tsx
@@ -1,42 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import App from "./App";
-import { ServerMessageType, type PresenterMode } from "./api/presenter";
 
 vi.mock("./hooks/useSession", () => ({
   useSession: () => true,
 }));
 
-vi.mock("./hooks/useExecute", () => ({
-  useExecute: () => ({ run: vi.fn(), running: false }),
-}));
-
 /** Default presenter state restored before each test. */
 const defaultPresenter = {
   page: 0,
-  mode: ServerMessageType.SlideSync as PresenterMode,
-  instruction: "",
-  placeholder: "",
   viewerCount: 0,
   pollStates: {} as Record<string, unknown>,
 };
 
 const mockPresenter: {
   page: number;
-  mode: PresenterMode;
-  instruction: string;
-  placeholder: string;
   viewerCount: number;
   pollStates: Record<string, unknown>;
-  sendSlideSync: ReturnType<typeof vi.fn>;
-  sendHandsOn: ReturnType<typeof vi.fn>;
   sendPollVote: ReturnType<typeof vi.fn>;
   sendPollUnvote: ReturnType<typeof vi.fn>;
   sendPollSwitch: ReturnType<typeof vi.fn>;
 } = {
   ...defaultPresenter,
-  sendSlideSync: vi.fn(),
-  sendHandsOn: vi.fn(),
   sendPollVote: vi.fn(),
   sendPollUnvote: vi.fn(),
   sendPollSwitch: vi.fn(),
@@ -46,89 +31,24 @@ vi.mock("./hooks/usePresenter", () => ({
   usePresenter: () => mockPresenter,
 }));
 
-const mockWrite = vi.fn();
-
-vi.mock("@xterm/xterm", () => {
-  return {
-    Terminal: class {
-      write = mockWrite;
-      writeln = vi.fn();
-      open = vi.fn();
-      dispose = vi.fn();
-      loadAddon = vi.fn();
-    },
-  };
-});
-
-vi.mock("@xterm/addon-fit", () => {
-  return {
-    FitAddon: class {
-      fit = vi.fn();
-    },
-  };
-});
-
-vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
-
 vi.mock("./slides/index", () => ({
-  slides: [() => <div>Test Slide</div>],
+  slides: [() => <div>Slide Zero</div>, () => <div>Slide One</div>, () => <div>Slide Two</div>],
 }));
+
+const scrollIntoViewMock = vi.fn();
 
 beforeEach(() => {
   Object.assign(mockPresenter, defaultPresenter);
-  mockWrite.mockClear();
+  scrollIntoViewMock.mockClear();
+  HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
 });
 
 describe("App", () => {
-  it("renders command input in hands-on mode", () => {
-    mockPresenter.mode = ServerMessageType.HandsOn;
+  it("renders all slides vertically", () => {
     render(<App />);
-    expect(screen.getByPlaceholderText("Enter command...")).toBeInTheDocument();
-  });
-
-  it("does not render command input in slide mode", () => {
-    render(<App />);
-    expect(screen.queryByPlaceholderText("Enter command...")).toBeNull();
-  });
-
-  it("writes initial prompt when session is ready", () => {
-    render(<App />);
-    expect(mockWrite).toHaveBeenCalledWith("$ ");
-  });
-
-  it("shows slide mode by default", () => {
-    render(<App />);
-    const slideMode = screen.getByRole("region", { name: "Slide mode" });
-    expect(slideMode.style.display).toBe("flex");
-    const handsOnMode = document.querySelector('[aria-label="Hands-on mode"]') as HTMLElement;
-    expect(handsOnMode.style.display).toBe("none");
-  });
-
-  it("hides instruction block when instruction is empty", () => {
-    render(<App />);
-    expect(screen.queryByText(/echo/)).toBeNull();
-  });
-
-  it("shows instruction block when instruction is provided", () => {
-    mockPresenter.instruction = "echo hello を実行してみよう";
-    render(<App />);
-    expect(screen.getByText("echo hello を実行してみよう")).toBeInTheDocument();
-  });
-
-  it("passes placeholder to command input", () => {
-    mockPresenter.placeholder = "$ echo hello";
-    mockPresenter.mode = ServerMessageType.HandsOn;
-    render(<App />);
-    expect(screen.getByPlaceholderText("$ echo hello")).toBeInTheDocument();
-  });
-
-  it("shows hands-on mode when mode is hands_on", () => {
-    mockPresenter.mode = ServerMessageType.HandsOn;
-    render(<App />);
-    const slideMode = document.querySelector('[aria-label="Slide mode"]') as HTMLElement;
-    expect(slideMode.style.display).toBe("none");
-    const handsOnMode = screen.getByRole("region", { name: "Hands-on mode" });
-    expect(handsOnMode.style.display).toBe("flex");
+    expect(screen.getByText("Slide Zero")).toBeInTheDocument();
+    expect(screen.getByText("Slide One")).toBeInTheDocument();
+    expect(screen.getByText("Slide Two")).toBeInTheDocument();
   });
 
   it("displays viewer count", () => {
@@ -137,46 +57,17 @@ describe("App", () => {
     expect(screen.getByText(/viewers/)).toHaveTextContent("42 viewers");
   });
 
-  it("places input as first child in hands-on mode", () => {
-    mockPresenter.mode = ServerMessageType.HandsOn;
+  it("scrolls to the active page on page change", () => {
+    mockPresenter.page = 1;
     render(<App />);
-    const handsOnMode = screen.getByRole("region", { name: "Hands-on mode" });
-    const firstChild = handsOnMode.children[0] as HTMLElement;
-    expect(firstChild.tagName).toBe("INPUT");
-    expect(firstChild.getAttribute("placeholder")).toBe("Enter command...");
+    expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
-  it("disables input when session is not ready", async () => {
-    vi.resetModules();
-    vi.doMock("./hooks/useSession", () => ({
-      useSession: () => false,
-    }));
-    vi.doMock("./hooks/useExecute", () => ({
-      useExecute: () => ({ run: vi.fn(), running: false }),
-    }));
-    mockPresenter.mode = ServerMessageType.HandsOn;
-    vi.doMock("./hooks/usePresenter", () => ({
-      usePresenter: () => mockPresenter,
-    }));
-    const { default: AppNoSession } = await import("./App");
-    render(<AppNoSession />);
-    expect(screen.getByPlaceholderText("Enter command...")).toBeDisabled();
-  });
-
-  it("disables input when command is running", async () => {
-    vi.resetModules();
-    vi.doMock("./hooks/useSession", () => ({
-      useSession: () => true,
-    }));
-    vi.doMock("./hooks/useExecute", () => ({
-      useExecute: () => ({ run: vi.fn(), running: true }),
-    }));
-    mockPresenter.mode = ServerMessageType.HandsOn;
-    vi.doMock("./hooks/usePresenter", () => ({
-      usePresenter: () => mockPresenter,
-    }));
-    const { default: AppRunning } = await import("./App");
-    render(<AppRunning />);
-    expect(screen.getByPlaceholderText("Enter command...")).toBeDisabled();
+  it("uses instant scroll for the first navigation", () => {
+    mockPresenter.page = 2;
+    render(<App />);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "instant" }),
+    );
   });
 });

--- a/front/src/App.test.tsx
+++ b/front/src/App.test.tsx
@@ -57,7 +57,7 @@ describe("App", () => {
     expect(screen.getByText(/viewers/)).toHaveTextContent("42 viewers");
   });
 
-  it("scrolls to the active page on page change", () => {
+  it("scrolls to the active page on initial render", () => {
     mockPresenter.page = 1;
     render(<App />);
     expect(scrollIntoViewMock).toHaveBeenCalled();
@@ -68,6 +68,16 @@ describe("App", () => {
     render(<App />);
     expect(scrollIntoViewMock).toHaveBeenCalledWith(
       expect.objectContaining({ behavior: "instant" }),
+    );
+  });
+
+  it("uses smooth scroll for subsequent navigations", () => {
+    const { rerender } = render(<App />);
+    scrollIntoViewMock.mockClear();
+    mockPresenter.page = 1;
+    rerender(<App />);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "smooth" }),
     );
   });
 });

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,44 +1,52 @@
 import type { ReactNode } from "react";
-import { useEffect, useRef } from "react";
-import Terminal, { type TerminalHandle } from "./components/Terminal";
-import CommandInput from "./components/CommandInput";
+import { useCallback, useEffect, useRef } from "react";
 import SlideView from "./components/SlideView";
-import { ServerMessageType } from "./api/presenter";
 import { useSession } from "./hooks/useSession";
-import { useExecute } from "./hooks/useExecute";
 import { usePresenter } from "./hooks/usePresenter";
+import { slides } from "./slides/index";
 
 /** WebSocket URL derived from the current page origin. */
 const wsUrl = (): string => location.origin.replace(/^http/, "ws") + "/ws";
 
-/** Root application component that wires session, terminal, slide view, and command input together. */
+/** Root application component that renders all slides vertically and scrolls to the active page. */
 const App = (): ReactNode => {
-  const ready = useSession();
-  const terminalRef = useRef<TerminalHandle>(null);
-  const { run, running } = useExecute(ready, terminalRef);
-  const {
-    page,
-    mode,
-    instruction,
-    placeholder,
-    viewerCount,
-    pollStates,
-    sendPollVote,
-    sendPollUnvote,
-    sendPollSwitch,
-  } = usePresenter(wsUrl());
+  useSession();
+  const { page, viewerCount, pollStates, sendPollVote, sendPollUnvote, sendPollSwitch } =
+    usePresenter(wsUrl());
 
-  useEffect(() => {
-    if (ready) {
-      terminalRef.current?.write("$ ");
-    }
-  }, [ready]);
+  const sectionRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const initialScrollDone = useRef(false);
+
+  /** Stores a section ref at the given index. */
+  const setSectionRef = useCallback(
+    (index: number) =>
+      (el: HTMLDivElement | null): void => {
+        sectionRefs.current[index] = el;
+      },
+    [],
+  );
+
+  /** Scroll to the active page when it changes. Uses instant scroll for the first navigation. */
+  useEffect((): void => {
+    const el = sectionRefs.current[page];
+    if (!el) return;
+    const behavior = initialScrollDone.current ? "smooth" : "instant";
+    initialScrollDone.current = true;
+    el.scrollIntoView({ behavior, block: "start" });
+  }, [page]);
 
   return (
-    <div style={{ position: "relative", height: "100dvh", background: "#000" }}>
+    <div
+      style={{
+        height: "100dvh",
+        overflowY: "auto",
+        scrollSnapType: "y mandatory",
+        background: "#000",
+      }}
+    >
       <div
         style={{
-          position: "absolute",
+          position: "fixed",
           top: 8,
           right: 8,
           zIndex: 10,
@@ -50,58 +58,24 @@ const App = (): ReactNode => {
         {viewerCount} viewers
       </div>
 
-      <div
-        role="region"
-        aria-label="Slide mode"
-        style={{
-          display: mode === ServerMessageType.SlideSync ? "flex" : "none",
-          flexDirection: "column",
-          height: "100%",
-        }}
-      >
-        <div style={{ flexGrow: 1, overflow: "hidden" }}>
+      {slides.map((_, i) => (
+        <div
+          key={i}
+          ref={setSectionRef(i)}
+          style={{
+            height: "100dvh",
+            scrollSnapAlign: "start",
+          }}
+        >
           <SlideView
-            page={page}
+            page={i}
             pollStates={pollStates}
             onPollVote={sendPollVote}
             onPollUnvote={sendPollUnvote}
             onPollSwitch={sendPollSwitch}
           />
         </div>
-        {instruction && (
-          <div
-            style={{
-              padding: "16px",
-              textAlign: "center",
-              color: "#888",
-              fontSize: "14px",
-              fontFamily: "sans-serif",
-              borderTop: "1px solid #333",
-            }}
-          >
-            {instruction}
-          </div>
-        )}
-      </div>
-
-      <div
-        role="region"
-        aria-label="Hands-on mode"
-        style={{
-          display: mode === ServerMessageType.HandsOn ? "flex" : "none",
-          flexDirection: "column",
-          height: "100%",
-        }}
-      >
-        {mode === ServerMessageType.HandsOn && (
-          <CommandInput
-            onSubmit={run}
-            disabled={!ready || running}
-            placeholder={placeholder || undefined}
-          />
-        )}
-        <Terminal ref={terminalRef} />
-      </div>
+      ))}
     </div>
   );
 };

--- a/front/src/hooks/usePresenter.test.ts
+++ b/front/src/hooks/usePresenter.test.ts
@@ -163,6 +163,12 @@ describe("usePresenter", () => {
     expect(result.current.page).toBe(0);
   });
 
+  it("sends get_state on connection open", () => {
+    renderPresenter();
+    simulateOpen();
+    expect(latest().sent).toContainEqual(JSON.stringify({ action: "message", type: "get_state" }));
+  });
+
   it("sends slide_sync message via sendSlideSync", () => {
     const { result } = renderPresenter();
     simulateOpen();
@@ -170,6 +176,7 @@ describe("usePresenter", () => {
       result.current.sendSlideSync(7);
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({ action: "message", type: Action.SlideSync, page: 7 }),
     ]);
   });
@@ -181,6 +188,7 @@ describe("usePresenter", () => {
       result.current.sendHandsOn("try this", "$ try");
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({
         action: "message",
         type: Action.HandsOn,
@@ -455,6 +463,7 @@ describe("usePresenter", () => {
       result.current.sendPollGet("q1", ["A", "B"], 1);
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({
         action: "message",
         type: ClientMessageType.PollGet,
@@ -472,6 +481,7 @@ describe("usePresenter", () => {
       result.current.sendPollVote("q1", "A");
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({
         action: "message",
         type: ClientMessageType.PollVote,
@@ -488,6 +498,7 @@ describe("usePresenter", () => {
       result.current.sendPollUnvote("q1", "A");
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({
         action: "message",
         type: ClientMessageType.PollUnvote,
@@ -504,6 +515,7 @@ describe("usePresenter", () => {
       result.current.sendPollSwitch("q1", "A", "B");
     });
     expect(latest().sent).toEqual([
+      JSON.stringify({ action: "message", type: "get_state" }),
       JSON.stringify({
         action: "message",
         type: ClientMessageType.PollSwitch,

--- a/front/src/hooks/usePresenter.ts
+++ b/front/src/hooks/usePresenter.ts
@@ -70,6 +70,7 @@ export const usePresenter = (
 
       ws.onopen = (): void => {
         delay = 1000;
+        ws.send(JSON.stringify({ action: "message", type: "get_state" }));
       };
 
       ws.onmessage = (event: MessageEvent): void => {


### PR DESCRIPTION
## Summary
- Viewer renders all slides vertically with `100dvh` sections and `scroll-snap`
- On WebSocket connect, sends `get_state` to receive current slide position
- First scroll uses `instant` behavior, subsequent changes use `smooth`
- Removed mode switching (slide_sync/hands_on) — all content is now vertical sections
- Viewer count overlay uses `position: fixed` to stay visible during scroll

## Test plan
- [x] `pnpm vp test` — 147 tests pass
- [ ] Open viewer, verify all slides visible by scrolling
- [ ] Presenter advances slide, verify viewer scrolls to correct position
- [ ] Late-joining viewer starts at correct slide position

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ページ変更時にアプリが自動でアクティブなスライドへスクロールします（最初は instant、その後は smooth）。

* **UI変更**
  * スライド表示を単一の縦スクロール可能コンテナへ移行し、スクロールスナップでスライドを整列するようになりました。

* **改善**
  * 初回レンダリング時にアクティブページへ確実にスクロールする挙動を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->