### PR TITLE
feat: integrate terminal into Slide0 and simplify sequence to SlideSync only

### DIFF
--- a/front/src/api/client.test.ts
+++ b/front/src/api/client.test.ts
@@ -105,6 +105,7 @@ describe("execute", () => {
       headers: { "Content-Type": "application/json" },
       credentials: "include",
       body: '{"command":"echo hello"}',
+      signal: undefined,
     });
   });
 
@@ -206,6 +207,39 @@ describe("execute", () => {
 
     expect(onReassigned).toHaveBeenCalledOnce();
     expect(events).toHaveLength(1);
+  });
+
+  it("forwards AbortSignal to fetch", async () => {
+    const chunks = ['data: {"type":"complete","exitCode":0}\n\n'];
+    const encoder = new TextEncoder();
+    const iterator = chunks[Symbol.iterator]();
+
+    const readable = new ReadableStream({
+      pull(controller) {
+        const { done, value } = iterator.next();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(encoder.encode(value));
+        }
+      },
+    });
+
+    mockFetch.mockResolvedValue({ ok: true, headers: new Headers(), body: readable });
+
+    const controller = new AbortController();
+    const events = [];
+    for await (const event of execute("ls", undefined, controller.signal)) {
+      events.push(event);
+    }
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/execute", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: '{"command":"ls"}',
+      signal: controller.signal,
+    });
   });
 
   it("does not call onReassigned when header is absent", async () => {

--- a/front/src/api/client.ts
+++ b/front/src/api/client.ts
@@ -41,16 +41,19 @@ export const deleteSession = (): void => {
  * The reader is automatically cancelled if the consumer exits early.
  * @param command - The shell command to execute.
  * @param onReassigned - Optional callback invoked when the session was reassigned due to a dead runner.
+ * @param signal - Optional AbortSignal to cancel the request and stream.
  */
 export async function* execute(
   command: string,
   onReassigned?: () => void,
+  signal?: AbortSignal,
 ): AsyncGenerator<SseEvent> {
   const res = await fetch("/api/execute", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
     body: JSON.stringify({ command }),
+    signal,
   });
   if (!res.ok) throw new Error(`Failed to execute: ${res.status}`);
   if (!res.body) throw new Error("No response body");

--- a/front/src/hooks/useExecute.test.ts
+++ b/front/src/hooks/useExecute.test.ts
@@ -160,4 +160,47 @@ describe("useExecute", () => {
     expect(writeln).toHaveBeenCalledWith("\x1b[31mError: connection refused\x1b[0m");
     expect(write).toHaveBeenCalledWith("$ ");
   });
+
+  it("aborts running command on unmount", async () => {
+    const { ref } = makeTerminalRef();
+
+    let resolveExecution!: () => void;
+    const executionPromise = new Promise<void>((resolve) => {
+      resolveExecution = resolve;
+    });
+
+    let receivedSignal: AbortSignal | undefined;
+
+    mockExecute.mockImplementation(
+      (_command: string, _onReassigned?: () => void, signal?: AbortSignal) => {
+        receivedSignal = signal;
+        return (async function* () {
+          await executionPromise;
+          yield { type: "complete" as const, exitCode: 0 };
+        })();
+      },
+    );
+
+    const { result, unmount } = renderHook(() => useExecute(true, ref));
+
+    act(() => {
+      void result.current.run("long-running");
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal!.aborted).toBe(false);
+
+    unmount();
+
+    expect(receivedSignal!.aborted).toBe(true);
+
+    resolveExecution();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+  });
 });

--- a/front/src/hooks/useExecute.ts
+++ b/front/src/hooks/useExecute.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { execute, SseEventType, type SseEvent } from "../api/client";
 import type { TerminalHandle } from "../components/Terminal";
 
@@ -22,10 +22,19 @@ export const useExecute = (
 ): UseExecuteResult => {
   const [running, setRunning] = useState(false);
   const runningRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
 
   const run = useCallback(
     async (command: string) => {
       if (!ready || runningRef.current) return;
+      const controller = new AbortController();
+      abortRef.current = controller;
       runningRef.current = true;
       setRunning(true);
 
@@ -37,13 +46,15 @@ export const useExecute = (
             "\x1b[33mSession was reassigned. Shell state has been reset.\x1b[0m",
           );
         };
-        for await (const event of execute(command, onReassigned)) {
+        for await (const event of execute(command, onReassigned, controller.signal)) {
           handleEvent(event, terminalRef);
         }
       } catch (error) {
+        if (controller.signal.aborted) return;
         const message = error instanceof Error ? error.message : "Unknown error";
         terminalRef.current?.writeln(`\x1b[31mError: ${message}\x1b[0m`);
       } finally {
+        if (abortRef.current === controller) abortRef.current = null;
         terminalRef.current?.write("$ ");
         runningRef.current = false;
         setRunning(false);

--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -15,13 +15,12 @@ describe("defaultSequence", () => {
     expect(first).toEqual({ type: Action.SlideSync, page: 0 });
   });
 
-  /** Verify that the default sequence contains 4 steps in the expected order. */
-  it("contains 4 steps in the expected order", () => {
-    expect(defaultSequence).toHaveLength(4);
+  /** Verify that the default sequence contains 3 slide_sync steps. */
+  it("contains 3 steps in the expected order", () => {
+    expect(defaultSequence).toHaveLength(3);
     expect(defaultSequence).toEqual([
       { type: Action.SlideSync, page: 0 },
       { type: Action.SlideSync, page: 1 },
-      { type: Action.HandsOn, instruction: "Try running a command", placeholder: "echo hello" },
       { type: Action.SlideSync, page: 2 },
     ]);
   });

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -18,7 +18,6 @@ export type PresenterStep = SlideSyncPayload | HandsOnPayload;
 export const defaultSequence: PresenterStep[] = [
   { type: Action.SlideSync, page: 0 },
   { type: Action.SlideSync, page: 1 },
-  { type: Action.HandsOn, instruction: "Try running a command", placeholder: "echo hello" },
   { type: Action.SlideSync, page: 2 },
 ];
 

--- a/front/src/slides/Slide0.tsx
+++ b/front/src/slides/Slide0.tsx
@@ -1,20 +1,40 @@
 import type { ReactNode } from "react";
+import { useRef } from "react";
 import type { SlideProps } from "../components/SlideView";
+import Terminal, { type TerminalHandle } from "../components/Terminal";
+import CommandInput from "../components/CommandInput";
+import { useSession } from "../hooks/useSession";
+import { useExecute } from "../hooks/useExecute";
 
-/** Title slide displayed as the first page of the presentation. */
-export const Slide0 = (_props: SlideProps): ReactNode => (
-  <div
-    style={{
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      width: "100%",
-      height: "100%",
-      color: "#fff",
-      fontSize: "min(6vw, 48px)",
-      fontFamily: "sans-serif",
-    }}
-  >
-    Welcome
-  </div>
-);
+/** Hands-on slide with embedded terminal and command input. */
+export const Slide0 = (_props: SlideProps): ReactNode => {
+  const ready = useSession();
+  const terminalRef = useRef<TerminalHandle>(null);
+  const { run, running } = useExecute(ready, terminalRef);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        background: "#000",
+      }}
+    >
+      <div
+        style={{
+          padding: "16px",
+          color: "#fff",
+          fontSize: "min(4vw, 20px)",
+          fontFamily: "sans-serif",
+          textAlign: "center",
+        }}
+      >
+        Try running a command
+      </div>
+      <CommandInput onSubmit={run} disabled={!ready || running} placeholder="echo hello" />
+      <Terminal ref={terminalRef} />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Slide0 now contains an embedded terminal with command input for hands-on exercises
- Presenter sequence simplified to all SlideSync steps, removing HandsOn step type
- Each slide component manages its own session and execution state internally

## Test plan
- [x] `pnpm vp test` — 147 tests pass
- [ ] Open viewer, verify Slide0 shows terminal with command input
- [ ] Presenter advances slides, verify all steps work as SlideSync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 最初のスライドがインタラクティブなターミナルとコマンド入力機能に対応しました。ユーザーはコマンドを実行できるようになります。

* **変更**
  * デフォルトのプレゼンテーション シーケンスが簡略化され、スライド同期ステップのみで構成されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->