### PR TITLE
ci: add Docker layer cache and backend readiness check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,8 +26,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Run integration tests
-        run: docker compose --env-file .env.example --profile integration run --rm integration-test
+        run: docker compose --env-file .env.example --profile integration run --rm --build integration-test
       - name: Cleanup
         if: always()
         run: docker compose --env-file .env.example --profile integration down -v
@@ -37,6 +38,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
@@ -48,10 +50,15 @@ jobs:
         run: cd front && pnpm exec playwright install --with-deps chromium
       - name: Wait for services
         run: |
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:5173 && exit 0
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5173 > /dev/null 2>&1 && \
+               curl -sf http://localhost:80/health > /dev/null 2>&1; then
+              echo "All services ready"
+              exit 0
+            fi
             sleep 2
           done
+          echo "Services did not become ready in time"
           exit 1
       - name: Run Playwright integration tests
         run: cd front && pnpm exec playwright test --config playwright.integration.config.ts

--- a/compose.yml
+++ b/compose.yml
@@ -5,6 +5,10 @@ services:
       args:
         NGINX_RESOLVER: 127.0.0.11
         BROKER_HOST: broker
+      cache_from:
+        - type=gha,scope=nginx
+      cache_to:
+        - type=gha,scope=nginx,mode=max
     profiles:
       - nginx
       - integration
@@ -12,7 +16,12 @@ services:
       - "${NGINX_PORT}:8080"
 
   broker:
-    build: broker/
+    build:
+      context: broker/
+      cache_from:
+        - type=gha,scope=broker
+      cache_to:
+        - type=gha,scope=broker,mode=max
     ports:
       - "${BROKER_PORT}:8080"
     env_file:
@@ -28,6 +37,10 @@ services:
     build:
       context: broker/
       target: test-integration
+      cache_from:
+        - type=gha,scope=broker
+      cache_to:
+        - type=gha,scope=broker,mode=max
     env_file:
       - broker/.env.example
     depends_on:
@@ -40,6 +53,10 @@ services:
     build:
       context: front/
       target: dev
+      cache_from:
+        - type=gha,scope=front
+      cache_to:
+        - type=gha,scope=front,mode=max
     ports:
       - "${FRONT_PORT}:5173"
     volumes:
@@ -52,7 +69,12 @@ services:
       - front
 
   runner-1:
-    build: runner/
+    build:
+      context: runner/
+      cache_from:
+        - type=gha,scope=runner
+      cache_to:
+        - type=gha,scope=runner,mode=max
     env_file:
       - runner/.env.example
     profiles:
@@ -60,7 +82,10 @@ services:
       - integration
 
   runner-2:
-    build: runner/
+    build:
+      context: runner/
+      cache_from:
+        - type=gha,scope=runner
     env_file:
       - runner/.env.example
     profiles:
@@ -94,7 +119,12 @@ services:
       - integration
 
   integration-test:
-    build: integration/
+    build:
+      context: integration/
+      cache_from:
+        - type=gha,scope=integration
+      cache_to:
+        - type=gha,scope=integration,mode=max
     environment:
       NGINX_URL: "http://nginx:8080"
       BROKER_URL: "http://broker:8080"


### PR DESCRIPTION
## Summary
- Add GHA Docker layer cache (`type=gha`) to all compose services via `cache_from`/`cache_to` in compose.yml
- Set up `docker/setup-buildx-action` in both integration CI jobs to enable GHA cache backend
- Fix "Wait for services" to also check `localhost:80/health` (nginx) in addition to front, preventing Playwright from running before backend is ready
- Increase wait loop from 30 to 60 iterations for slower CI environments

## Test plan
- [ ] CI `integration-go` passes
- [ ] CI `integration-e2e` passes
- [ ] Second CI run is faster due to Docker layer cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CDパイプラインの信頼性向上のため、Docker Buildxのセットアップを統合ワークフローに追加しました。
  * サービス起動確認プロセスを改善し、複数エンドポイントのヘルスチェック対応を追加しました。
  * Dockerイメージビルドの効率化のため、BuildKitキャッシュディレクティブを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->