### PR TITLE
feat: fail-open on LLM validation API errors

### DIFF
--- a/runner/handler.go
+++ b/runner/handler.go
@@ -136,11 +136,15 @@ func handleExecute(sm *SessionManager, v Validator) gin.HandlerFunc {
 			}
 			result, err := v.Validate(c.Request.Context(), req.Command)
 			if err != nil {
-				auditLog(id, remote, class, req.Command, nil, err)
-				c.JSON(http.StatusForbidden, errorResponse{Error: "command not allowed"})
-				return
-			}
-			if !result.Safe {
+				var unavail *ValidationUnavailableError
+				if errors.As(err, &unavail) {
+					auditLog(id, remote, "validation-skipped", req.Command, nil, err)
+				} else {
+					auditLog(id, remote, class, req.Command, nil, err)
+					c.JSON(http.StatusForbidden, errorResponse{Error: "command not allowed"})
+					return
+				}
+			} else if !result.Safe {
 				auditLog(id, remote, "rejected", req.Command, nil, fmt.Errorf("reason: %s", result.Reason))
 				c.JSON(http.StatusForbidden, errorResponse{Error: fmt.Sprintf("command not allowed: %s", result.Reason)})
 				return

--- a/runner/handler_test.go
+++ b/runner/handler_test.go
@@ -602,6 +602,9 @@ func TestExecuteValidatorUnavailableSkipsValidation(t *testing.T) {
 	}
 
 	events := parseSSEEvents(t, w.Body.String())
+	if len(events) == 0 {
+		t.Fatal("expected at least 1 SSE event, got 0")
+	}
 	last := events[len(events)-1]
 	if last.Type != "complete" || last.ExitCode == nil || *last.ExitCode != 0 {
 		t.Fatalf("expected complete with exitCode=0, got %+v", last)

--- a/runner/handler_test.go
+++ b/runner/handler_test.go
@@ -550,12 +550,12 @@ func TestExecuteValidatedUnsafe(t *testing.T) {
 	}
 }
 
-// TestExecuteValidatorError verifies that a validator error results in
-// 403 fail-closed behavior.
+// TestExecuteValidatorError verifies that a non-API validator error such as
+// a parse failure results in 403 fail-closed behavior.
 func TestExecuteValidatorError(t *testing.T) {
 	sm := NewSessionManager()
 	defer sm.CloseAll()
-	v := &mockValidator{err: errors.New("LLM unavailable")}
+	v := &mockValidator{err: errors.New("retries exhausted: no expected tool use block in response")}
 	handler := newHandler(sm, v)
 
 	id, _, err := sm.Create()
@@ -571,6 +571,40 @@ func TestExecuteValidatorError(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+// TestExecuteValidatorUnavailableSkipsValidation verifies that when the
+// validator returns a ValidationUnavailableError the command executes
+// instead of being rejected with 403.
+func TestExecuteValidatorUnavailableSkipsValidation(t *testing.T) {
+	sm := NewSessionManager()
+	defer sm.CloseAll()
+	sm.newShell = func() (Shell, error) {
+		return &mockShell{exitCode: 0}, nil
+	}
+	v := &mockValidator{err: &ValidationUnavailableError{Cause: errors.New("429")}}
+	handler := newHandler(sm, v)
+
+	id, _, err := sm.Create()
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	body := strings.NewReader(`{"command":"echo hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/execute", body)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: id})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	events := parseSSEEvents(t, w.Body.String())
+	last := events[len(events)-1]
+	if last.Type != "complete" || last.ExitCode == nil || *last.ExitCode != 0 {
+		t.Fatalf("expected complete with exitCode=0, got %+v", last)
 	}
 }
 

--- a/runner/integration_test.go
+++ b/runner/integration_test.go
@@ -395,6 +395,9 @@ func TestIntegrationValidationUnavailableFailOpen(t *testing.T) {
 		t.Fatalf("read body error: %v", err)
 	}
 	events := parseIntegrationSSEEvents(t, buf.String())
+	if len(events) == 0 {
+		t.Fatal("expected at least 1 SSE event, got 0")
+	}
 	last := events[len(events)-1]
 	if last.Type != "complete" || last.ExitCode == nil || *last.ExitCode != 0 {
 		t.Fatalf("last event = %+v, want complete with exitCode=0", last)

--- a/runner/integration_test.go
+++ b/runner/integration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -357,6 +358,46 @@ func TestIntegrationConcurrentExecute(t *testing.T) {
 		if last.Type != "complete" || last.ExitCode == nil || *last.ExitCode != 0 {
 			t.Fatalf("request %d: last event = %+v, want complete with exitCode=0", i, last)
 		}
+	}
+}
+
+// TestIntegrationValidationUnavailableFailOpen verifies that when the validator
+// returns a ValidationUnavailableError the command executes through the full
+// HTTP stack instead of being rejected.
+func TestIntegrationValidationUnavailableFailOpen(t *testing.T) {
+	sm := NewSessionManager()
+	defer sm.CloseAll()
+
+	v := &mockValidator{err: &ValidationUnavailableError{Cause: errors.New("throttling")}}
+	ts := httptest.NewServer(newHandler(sm, v))
+	defer ts.Close()
+
+	sid := createSession(t, ts)
+
+	body := marshalCommand(t, "echo hello")
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/execute", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: sid})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/execute error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var buf strings.Builder
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		t.Fatalf("read body error: %v", err)
+	}
+	events := parseIntegrationSSEEvents(t, buf.String())
+	last := events[len(events)-1]
+	if last.Type != "complete" || last.ExitCode == nil || *last.ExitCode != 0 {
+		t.Fatalf("last event = %+v, want complete with exitCode=0", last)
 	}
 }
 

--- a/runner/llm_validator.go
+++ b/runner/llm_validator.go
@@ -75,6 +75,22 @@ var toolSchema = document.NewLazyDocument(map[string]interface{}{
 // the response cannot be parsed. Total attempts = 1 + maxRetries.
 const maxRetries = 2
 
+// ValidationUnavailableError indicates that the LLM validation service
+// is temporarily unavailable due to an API or network error.
+type ValidationUnavailableError struct {
+	Cause error
+}
+
+// Error returns a human-readable message describing the unavailable validation.
+func (e *ValidationUnavailableError) Error() string {
+	return fmt.Sprintf("validation unavailable: %v", e.Cause)
+}
+
+// Unwrap returns the underlying cause of the validation unavailability.
+func (e *ValidationUnavailableError) Unwrap() error {
+	return e.Cause
+}
+
 // BedrockValidator validates commands using Bedrock Converse API with tool use.
 type BedrockValidator struct {
 	client  BedrockConverseClient
@@ -121,7 +137,7 @@ func (v *BedrockValidator) Validate(ctx context.Context, command string) (Valida
 	for range maxRetries + 1 {
 		output, err := v.client.Converse(ctx, input)
 		if err != nil {
-			return ValidationResult{}, fmt.Errorf("bedrock converse: %w", err)
+			return ValidationResult{}, &ValidationUnavailableError{Cause: err}
 		}
 
 		var result ValidationResult

--- a/runner/llm_validator_test.go
+++ b/runner/llm_validator_test.go
@@ -120,7 +120,7 @@ func TestValidateUnsafe(t *testing.T) {
 }
 
 // TestValidateAPIError verifies that an API error from the Bedrock client
-// is propagated immediately without retry.
+// is propagated as a ValidationUnavailableError immediately without retry.
 func TestValidateAPIError(t *testing.T) {
 	client := &mockBedrockClient{
 		err: errors.New("service unavailable"),
@@ -131,8 +131,12 @@ func TestValidateAPIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
+	var unavail *ValidationUnavailableError
+	if !errors.As(err, &unavail) {
+		t.Fatalf("error type = %T, want *ValidationUnavailableError", err)
+	}
 	if !errors.Is(err, client.err) {
-		t.Fatalf("error = %v, want wrapping %v", err, client.err)
+		t.Fatalf("Unwrap() = %v, want %v", unavail.Unwrap(), client.err)
 	}
 	if client.calls != 1 {
 		t.Fatalf("calls = %d, want 1 since API errors are not retried", client.calls)
@@ -269,8 +273,8 @@ func TestValidateRetrySucceeds(t *testing.T) {
 }
 
 // TestValidateRetryAPIError verifies that when the first attempt fails to
-// parse but the second attempt returns an API error, the API error is returned
-// immediately.
+// parse but the second attempt returns an API error, a ValidationUnavailableError
+// is returned immediately.
 func TestValidateRetryAPIError(t *testing.T) {
 	client := &mockBedrockClient{
 		outputs: []*bedrockruntime.ConverseOutput{
@@ -284,6 +288,10 @@ func TestValidateRetryAPIError(t *testing.T) {
 	_, err := v.Validate(context.Background(), "ls")
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	var unavail *ValidationUnavailableError
+	if !errors.As(err, &unavail) {
+		t.Fatalf("error type = %T, want *ValidationUnavailableError", err)
 	}
 	if !strings.Contains(err.Error(), "api down") {
 		t.Fatalf("error = %v, want containing 'api down'", err)
@@ -341,6 +349,21 @@ func TestValidateWrongToolNameIgnored(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "retries exhausted") {
 		t.Fatalf("error = %v, want containing 'retries exhausted'", err)
+	}
+}
+
+// TestValidationUnavailableErrorMessage verifies that ValidationUnavailableError
+// produces the expected error message and correctly unwraps to the cause.
+func TestValidationUnavailableErrorMessage(t *testing.T) {
+	cause := errors.New("connection refused")
+	err := &ValidationUnavailableError{Cause: cause}
+
+	want := "validation unavailable: connection refused"
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+	if err.Unwrap() != cause {
+		t.Fatalf("Unwrap() = %v, want %v", err.Unwrap(), cause)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `ValidationUnavailableError` type to distinguish transient API errors from parse errors in LLM validation
- Handler now falls through to execute on API errors (fail-open) instead of returning 403
- Parse errors (LLM reachable but gave bad output) still fail-closed with 403

## Test plan
- [x] `docker build --target test runner/` passes (100% coverage)
- [x] `TestValidateAPIError` / `TestValidateRetryAPIError` assert `ValidationUnavailableError`
- [x] `TestValidationUnavailableErrorMessage` covers Error() and Unwrap()
- [x] `TestExecuteValidatorUnavailableSkipsValidation` verifies fail-open (HTTP 200 + SSE)
- [x] `TestExecuteValidatorError` verifies fail-closed on parse errors (HTTP 403)
- [x] `TestIntegrationValidationUnavailableFailOpen` verifies full HTTP stack fail-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * バリデーション機能が一時的に利用不可な場合、リクエストがブロックされずに処理が続行されるよう改善。監査ログへのより詳細な記録に対応。

* **テスト**
  * バリデーション不可シナリオに対する包括的なテストカバレッジを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->