### PR TITLE
refactor: remove HandsOn message type from frontend

### DIFF
--- a/front/src/api/presenter.test.ts
+++ b/front/src/api/presenter.test.ts
@@ -8,15 +8,6 @@ describe("parsePresenterMessage", () => {
     ).toEqual({ type: "slide_sync", page: 3 });
   });
 
-  it("parses hands_on message", () => {
-    const msg = {
-      type: ServerMessageType.HandsOn,
-      instruction: "run echo",
-      placeholder: "$ echo hi",
-    };
-    expect(parsePresenterMessage(JSON.stringify(msg))).toEqual(msg);
-  });
-
   it("parses viewer_count message", () => {
     expect(
       parsePresenterMessage(JSON.stringify({ type: ServerMessageType.ViewerCount, count: 42 })),
@@ -50,14 +41,6 @@ describe("parsePresenterMessage", () => {
   it("returns null for invalid viewer_count payload shape", () => {
     expect(
       parsePresenterMessage(JSON.stringify({ type: ServerMessageType.ViewerCount, count: "42" })),
-    ).toBeNull();
-  });
-
-  it("returns null for invalid hands_on payload shape", () => {
-    expect(
-      parsePresenterMessage(
-        JSON.stringify({ type: ServerMessageType.HandsOn, instruction: 123, placeholder: null }),
-      ),
     ).toBeNull();
   });
 

--- a/front/src/api/presenter.ts
+++ b/front/src/api/presenter.ts
@@ -1,7 +1,6 @@
 /** Direction-independent action identifiers shared across presenter protocol and presenter-step modeling. */
 export const Action = {
   SlideSync: "slide_sync",
-  HandsOn: "hands_on",
   ViewerCount: "viewer_count",
   PollState: "poll_state",
   PollError: "poll_error",
@@ -15,7 +14,6 @@ export const Action = {
 /** Discriminant values for server-to-client presenter messages. */
 export const ServerMessageType = {
   SlideSync: Action.SlideSync,
-  HandsOn: Action.HandsOn,
   ViewerCount: Action.ViewerCount,
   PollState: Action.PollState,
   PollError: Action.PollError,
@@ -31,13 +29,6 @@ export const ClientMessageType = {
 
 /** Slide page synchronization payload shared by server messages and presenter steps. */
 export type SlideSyncPayload = { type: typeof Action.SlideSync; page: number };
-
-/** Hands-on mode payload shared by server messages and presenter steps. */
-export type HandsOnPayload = {
-  type: typeof Action.HandsOn;
-  instruction: string;
-  placeholder: string;
-};
 
 /** Viewer count notification payload. */
 export type ViewerCountPayload = { type: typeof Action.ViewerCount; count: number };
@@ -64,13 +55,9 @@ export type PollErrorPayload = {
 /** Discriminated union of all server-to-client presenter messages. */
 export type PresenterMessage =
   | SlideSyncPayload
-  | HandsOnPayload
   | ViewerCountPayload
   | PollStatePayload
   | PollErrorPayload;
-
-/** Display mode driven by the presenter. */
-export type PresenterMode = typeof Action.SlideSync | typeof Action.HandsOn;
 
 /** Check whether a value is a string. */
 const isString = (v: unknown): v is string => typeof v === "string";
@@ -93,10 +80,6 @@ const isVotesRecord = (v: unknown): v is Record<string, number> =>
 
 /** Validate that msg has the shape of a SlideSync payload. */
 const isSlideSyncPayload = (msg: Record<string, unknown>): boolean => isNumber(msg.page);
-
-/** Validate that msg has the shape of a HandsOn payload. */
-const isHandsOnPayload = (msg: Record<string, unknown>): boolean =>
-  isString(msg.instruction) && isString(msg.placeholder);
 
 /** Validate that msg has the shape of a ViewerCount payload. */
 const isViewerCountPayload = (msg: Record<string, unknown>): boolean => isNumber(msg.count);
@@ -131,15 +114,6 @@ export const parsePresenterMessage = (raw: string): PresenterMessage | null => {
     if (msg.type === ServerMessageType.SlideSync) {
       return isSlideSyncPayload(msg)
         ? { type: ServerMessageType.SlideSync, page: msg.page as number }
-        : null;
-    }
-    if (msg.type === ServerMessageType.HandsOn) {
-      return isHandsOnPayload(msg)
-        ? {
-            type: ServerMessageType.HandsOn,
-            instruction: msg.instruction as string,
-            placeholder: msg.placeholder as string,
-          }
         : null;
     }
     if (msg.type === ServerMessageType.ViewerCount) {

--- a/front/src/hooks/usePresenter.test.ts
+++ b/front/src/hooks/usePresenter.test.ts
@@ -81,37 +81,17 @@ describe("usePresenter", () => {
   it("returns initial state", () => {
     const { result } = renderPresenter();
     expect(result.current.page).toBe(0);
-    expect(result.current.mode).toBe(ServerMessageType.SlideSync);
-    expect(result.current.instruction).toBe("");
-    expect(result.current.placeholder).toBe("");
+    expect(result.current.viewerCount).toBe(0);
     expect(result.current.viewerCount).toBe(0);
   });
 
-  it("updates page and sets mode to slide_sync on slide_sync message", () => {
+  it("updates page on slide_sync message", () => {
     const { result } = renderPresenter();
     simulateOpen();
     act(() => {
       simulateMessage(JSON.stringify({ type: ServerMessageType.SlideSync, page: 5 }));
     });
     expect(result.current.page).toBe(5);
-    expect(result.current.mode).toBe(ServerMessageType.SlideSync);
-  });
-
-  it("updates instruction, placeholder, and sets mode to hands_on on hands_on message", () => {
-    const { result } = renderPresenter();
-    simulateOpen();
-    act(() => {
-      simulateMessage(
-        JSON.stringify({
-          type: ServerMessageType.HandsOn,
-          instruction: "run echo",
-          placeholder: "$ echo hi",
-        }),
-      );
-    });
-    expect(result.current.mode).toBe(ServerMessageType.HandsOn);
-    expect(result.current.instruction).toBe("run echo");
-    expect(result.current.placeholder).toBe("$ echo hi");
   });
 
   it("updates viewerCount on viewer_count message", () => {
@@ -123,27 +103,6 @@ describe("usePresenter", () => {
     expect(result.current.viewerCount).toBe(42);
   });
 
-  it("switches from hands_on back to slide_sync on slide_sync", () => {
-    const { result } = renderPresenter();
-    simulateOpen();
-    act(() => {
-      simulateMessage(
-        JSON.stringify({
-          type: ServerMessageType.HandsOn,
-          instruction: "do something",
-          placeholder: "$ ...",
-        }),
-      );
-    });
-    expect(result.current.mode).toBe(ServerMessageType.HandsOn);
-
-    act(() => {
-      simulateMessage(JSON.stringify({ type: ServerMessageType.SlideSync, page: 3 }));
-    });
-    expect(result.current.mode).toBe(ServerMessageType.SlideSync);
-    expect(result.current.page).toBe(3);
-  });
-
   it("ignores unknown message types", () => {
     const { result } = renderPresenter();
     simulateOpen();
@@ -151,7 +110,6 @@ describe("usePresenter", () => {
       simulateMessage(JSON.stringify({ type: "unknown" }));
     });
     expect(result.current.page).toBe(0);
-    expect(result.current.mode).toBe(ServerMessageType.SlideSync);
   });
 
   it("ignores malformed JSON messages", () => {
@@ -181,33 +139,10 @@ describe("usePresenter", () => {
     ]);
   });
 
-  it("sends hands_on message via sendHandsOn", () => {
-    const { result } = renderPresenter();
-    simulateOpen();
-    act(() => {
-      result.current.sendHandsOn("try this", "$ try");
-    });
-    expect(latest().sent).toEqual([
-      JSON.stringify({ action: "message", type: "get_state" }),
-      JSON.stringify({
-        action: "message",
-        type: Action.HandsOn,
-        instruction: "try this",
-        placeholder: "$ try",
-      }),
-    ]);
-  });
-
   it("does not throw sendSlideSync after unmount", () => {
     const { result, unmount } = renderPresenter();
     unmount();
     expect(() => result.current.sendSlideSync(1)).not.toThrow();
-  });
-
-  it("does not throw sendHandsOn after unmount", () => {
-    const { result, unmount } = renderPresenter();
-    unmount();
-    expect(() => result.current.sendHandsOn("test", "ph")).not.toThrow();
   });
 
   it("closes WebSocket on unmount", () => {
@@ -391,7 +326,7 @@ describe("usePresenter", () => {
     });
   });
 
-  it("does not change mode on poll_state message", () => {
+  it("does not change page on poll_state message", () => {
     const { result } = renderPresenter();
     simulateOpen();
     act(() => {
@@ -406,7 +341,7 @@ describe("usePresenter", () => {
         }),
       );
     });
-    expect(result.current.mode).toBe(ServerMessageType.SlideSync);
+    expect(result.current.page).toBe(0);
   });
 
   it("updates pollStates votes and myChoices on poll_error message", () => {

--- a/front/src/hooks/usePresenter.ts
+++ b/front/src/hooks/usePresenter.ts
@@ -4,7 +4,6 @@ import {
   ClientMessageType,
   ServerMessageType,
   parsePresenterMessage,
-  type PresenterMode,
 } from "../api/presenter";
 
 /** Maximum reconnection delay in milliseconds. */
@@ -21,13 +20,9 @@ export interface PollStateData {
 /** Return value of the usePresenter hook. */
 export interface UsePresenterResult {
   page: number;
-  mode: PresenterMode;
-  instruction: string;
-  placeholder: string;
   viewerCount: number;
   pollStates: Partial<Record<string, PollStateData>>;
   sendSlideSync: (page: number) => void;
-  sendHandsOn: (instruction: string, placeholder: string) => void;
   sendPollGet: (pollId: string, options: string[], maxChoices: number) => void;
   sendPollVote: (pollId: string, choice: string) => void;
   sendPollUnvote: (pollId: string, choice: string) => void;
@@ -40,7 +35,7 @@ export interface UsePresenterDeps {
 }
 
 /**
- * Hook that manages a presenter WebSocket connection including page, mode, viewer count, and poll states keyed by pollId.
+ * Hook that manages a presenter WebSocket connection including page, viewer count, and poll states keyed by pollId.
  * Connects on mount with auto-reconnect and disconnects on unmount.
  * @param wsUrl - WebSocket URL to connect to.
  * @param deps - Optional dependency overrides for testing.
@@ -51,9 +46,6 @@ export const usePresenter = (
   deps?: Partial<UsePresenterDeps>,
 ): UsePresenterResult => {
   const [page, setPage] = useState(0);
-  const [mode, setMode] = useState<PresenterMode>(ServerMessageType.SlideSync);
-  const [instruction, setInstruction] = useState("");
-  const [placeholder, setPlaceholder] = useState("");
   const [viewerCount, setViewerCount] = useState(0);
   const [pollStates, setPollStates] = useState<Record<string, PollStateData>>({});
   const wsRef = useRef<WebSocket | null>(null);
@@ -79,12 +71,6 @@ export const usePresenter = (
         switch (msg.type) {
           case ServerMessageType.SlideSync:
             setPage(msg.page);
-            setMode(ServerMessageType.SlideSync);
-            break;
-          case ServerMessageType.HandsOn:
-            setInstruction(msg.instruction);
-            setPlaceholder(msg.placeholder);
-            setMode(ServerMessageType.HandsOn);
             break;
           case ServerMessageType.ViewerCount:
             setViewerCount(msg.count);
@@ -134,19 +120,9 @@ export const usePresenter = (
     };
   }, [wsUrl, deps?.WebSocket]);
 
+  /** Send a slide_sync message to synchronize viewers to a given page. */
   const sendSlideSync = useCallback((p: number): void => {
     wsRef.current?.send(JSON.stringify({ action: "message", type: Action.SlideSync, page: p }));
-  }, []);
-
-  const sendHandsOn = useCallback((inst: string, ph: string): void => {
-    wsRef.current?.send(
-      JSON.stringify({
-        action: "message",
-        type: Action.HandsOn,
-        instruction: inst,
-        placeholder: ph,
-      }),
-    );
   }, []);
 
   /** Send a poll_get message to initialize or retrieve a poll. */
@@ -185,13 +161,9 @@ export const usePresenter = (
 
   return {
     page,
-    mode,
-    instruction,
-    placeholder,
     viewerCount,
     pollStates,
     sendSlideSync,
-    sendHandsOn,
     sendPollGet,
     sendPollVote,
     sendPollUnvote,

--- a/front/src/presenter/PresenterPanel.test.tsx
+++ b/front/src/presenter/PresenterPanel.test.tsx
@@ -7,8 +7,8 @@ vi.mock("./sequence", async () => {
   return {
     defaultSequence: [
       { type: Action.SlideSync, page: 0 },
-      { type: Action.HandsOn, instruction: "Run echo", placeholder: "echo hello" },
       { type: Action.SlideSync, page: 1 },
+      { type: Action.SlideSync, page: 2 },
     ],
     defaultPolls: [],
   };
@@ -17,10 +17,8 @@ vi.mock("./sequence", async () => {
 /** Creates a fresh set of props with mock send functions for each test. */
 const createProps = (): PresenterPanelProps & {
   sendSlideSync: Mock;
-  sendHandsOn: Mock;
 } => ({
   sendSlideSync: vi.fn(),
-  sendHandsOn: vi.fn(),
   viewerCount: 0,
 });
 
@@ -63,12 +61,11 @@ describe("PresenterPanel", () => {
     expect(screen.getByRole("button", { name: "Next" }).hasAttribute("disabled")).toBe(false);
   });
 
-  /** Verify that advancing calls sendHandsOn for the hands_on step. */
-  it("advances step and calls sendHandsOn on next", async () => {
+  /** Verify that advancing calls sendSlideSync for the next step. */
+  it("advances step and calls sendSlideSync on next", async () => {
     await renderPanel();
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    expect(props.sendHandsOn).toHaveBeenCalledWith("Run echo", "echo hello");
-    expect(props.sendHandsOn).toHaveBeenCalledTimes(1);
+    expect(props.sendSlideSync).toHaveBeenCalledWith(1);
     expect(screen.getByText(/Step 2 \/ 3/)).toBeTruthy();
   });
 
@@ -93,8 +90,7 @@ describe("PresenterPanel", () => {
   it("advances step on ArrowRight key", async () => {
     await renderPanel();
     fireEvent.keyDown(window, { key: "ArrowRight" });
-    expect(props.sendHandsOn).toHaveBeenCalledWith("Run echo", "echo hello");
-    expect(props.sendHandsOn).toHaveBeenCalledTimes(1);
+    expect(props.sendSlideSync).toHaveBeenCalledWith(1);
     expect(screen.getByText(/Step 2 \/ 3/)).toBeTruthy();
   });
 
@@ -129,16 +125,9 @@ describe("PresenterPanel", () => {
     expect(props.sendSlideSync).toHaveBeenCalledTimes(1);
   });
 
-  /** Verify that slide_sync step shows the correct description. */
-  it("displays step description for slide_sync step", async () => {
+  /** Verify that slide step shows the correct description. */
+  it("displays step description", async () => {
     await renderPanel();
     expect(screen.getByText("Slide 0")).toBeTruthy();
-  });
-
-  /** Verify that hands_on step shows the correct description. */
-  it("displays step description for hands_on step", async () => {
-    await renderPanel();
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    expect(screen.getByText("Hands-on: Run echo")).toBeTruthy();
   });
 });

--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -1,33 +1,19 @@
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { Action } from "../api/presenter";
 import { defaultSequence, type PresenterStep } from "./sequence";
 
 /** Props for the PresenterPanel component. */
 export interface PresenterPanelProps {
   /** Sends a slide_sync message to synchronize viewers to a given page. */
   sendSlideSync: (page: number) => void;
-  /** Sends a hands_on message with instruction and placeholder text. */
-  sendHandsOn: (instruction: string, placeholder: string) => void;
   /** Number of currently connected viewers. */
   viewerCount: number;
 }
 
 /** Derives a human-readable description from a presenter step. */
-const describeStep = (step: PresenterStep): string => {
-  switch (step.type) {
-    case Action.SlideSync:
-      return `Slide ${step.page}`;
-    case Action.HandsOn:
-      return `Hands-on: ${step.instruction}`;
-  }
-};
+const describeStep = (step: PresenterStep): string => `Slide ${step.page}`;
 
 /** Presenter control panel that drives the presentation sequence via step navigation. */
-export const PresenterPanel = ({
-  sendSlideSync,
-  sendHandsOn,
-  viewerCount,
-}: PresenterPanelProps): ReactNode => {
+export const PresenterPanel = ({ sendSlideSync, viewerCount }: PresenterPanelProps): ReactNode => {
   const sequence = defaultSequence;
   const [stepIndex, setStepIndex] = useState(0);
   const lastExecutedRef = useRef<number | null>(null);
@@ -35,16 +21,9 @@ export const PresenterPanel = ({
   /** Executes the send function corresponding to a given step. */
   const executeStep = useCallback(
     (step: PresenterStep): void => {
-      switch (step.type) {
-        case Action.SlideSync:
-          sendSlideSync(step.page);
-          break;
-        case Action.HandsOn:
-          sendHandsOn(step.instruction, step.placeholder);
-          break;
-      }
+      sendSlideSync(step.page);
     },
-    [sendSlideSync, sendHandsOn],
+    [sendSlideSync],
   );
 
   /** Navigates to a specific step index. */

--- a/front/src/presenter/main.tsx
+++ b/front/src/presenter/main.tsx
@@ -44,7 +44,7 @@ const PresenterApp = (): ReactNode => {
 
 /** Inner component rendered after login that connects the usePresenter hook to the PresenterPanel. */
 const PresenterAppInner = (): ReactNode => {
-  const { viewerCount, sendSlideSync, sendHandsOn, sendPollGet } = usePresenter(wsUrl());
+  const { viewerCount, sendSlideSync, sendPollGet } = usePresenter(wsUrl());
 
   /** Send all poll definitions on mount to initialize polls. */
   useEffect((): void => {
@@ -53,13 +53,7 @@ const PresenterAppInner = (): ReactNode => {
     }
   }, [sendPollGet]);
 
-  return (
-    <PresenterPanel
-      sendSlideSync={sendSlideSync}
-      sendHandsOn={sendHandsOn}
-      viewerCount={viewerCount}
-    />
-  );
+  return <PresenterPanel sendSlideSync={sendSlideSync} viewerCount={viewerCount} />;
 };
 
 const root = document.getElementById("presenter-root");

--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Action } from "../api/presenter";
-import { defaultPolls, defaultSequence, type PresenterStep } from "./sequence";
+import { defaultPolls, defaultSequence } from "./sequence";
 
 describe("defaultSequence", () => {
   /** Verify that the default sequence is a non-empty array. */
@@ -24,41 +24,12 @@ describe("defaultSequence", () => {
       { type: Action.SlideSync, page: 2 },
     ]);
   });
-});
 
-describe("PresenterStep discriminated union", () => {
-  /** Verify that a slide_sync step carries the page property. */
-  it("allows slide_sync with page", () => {
-    const step: PresenterStep = { type: Action.SlideSync, page: 3 };
-    expect(step.type).toBe(Action.SlideSync);
-    if (step.type === Action.SlideSync) {
-      expect(step.page).toBe(3);
+  /** Verify that all steps are slide_sync type. */
+  it("only contains slide_sync steps", () => {
+    for (const step of defaultSequence) {
+      expect(step.type).toBe(Action.SlideSync);
     }
-  });
-
-  /** Verify that a hands_on step carries instruction and placeholder properties. */
-  it("allows hands_on with instruction and placeholder", () => {
-    const step: PresenterStep = {
-      type: Action.HandsOn,
-      instruction: "Run the command",
-      placeholder: "echo hello",
-    };
-    expect(step.type).toBe(Action.HandsOn);
-    if (step.type === Action.HandsOn) {
-      expect(step.instruction).toBe("Run the command");
-      expect(step.placeholder).toBe("echo hello");
-    }
-  });
-
-  /** Verify that all step types are present in the expected order. */
-  it("collects expected ordered types", () => {
-    const steps: PresenterStep[] = [
-      { type: Action.SlideSync, page: 1 },
-      { type: Action.HandsOn, instruction: "do it", placeholder: "cmd" },
-    ];
-
-    const types = steps.map((s) => s.type);
-    expect(types).toEqual([Action.SlideSync, Action.HandsOn]);
   });
 });
 

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -1,4 +1,4 @@
-import { Action, type HandsOnPayload, type SlideSyncPayload } from "../api/presenter";
+import { Action, type SlideSyncPayload } from "../api/presenter";
 
 /** Poll open payload used only in presenter steps to initialize a poll for viewers. */
 export type PollOpenPayload = {
@@ -8,11 +8,8 @@ export type PollOpenPayload = {
   maxChoices: number;
 };
 
-/**
- * Discriminated union type representing a single display-mode step in the presentation sequence.
- * SlideSyncPayload and HandsOnPayload are shared with server-to-client message types.
- */
-export type PresenterStep = SlideSyncPayload | HandsOnPayload;
+/** A single step in the presentation sequence. All steps are slide_sync. */
+export type PresenterStep = SlideSyncPayload;
 
 /** Default presentation sequence used by the presenter control panel. */
 export const defaultSequence: PresenterStep[] = [


### PR DESCRIPTION
## Summary
- Remove `HandsOnPayload`, `PresenterMode`, `sendHandsOn`, and all HandsOn branches from the presenter protocol, hooks, and components
- Presenter sequence now contains only `SlideSync` steps
- `App.tsx` no longer switches between slide and hands-on modes
- Go-side `hands_on` handler removal is deferred to a follow-up PR

## Test plan
- [x] `pnpm vp test` — 135 tests pass
- [ ] Presenter page works with only SlideSync steps
- [ ] Viewer page renders slides without mode switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)