### PR TITLE
feat: add session retry with terminal status display

### DIFF
--- a/front/src/App.test.tsx
+++ b/front/src/App.test.tsx
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import App from "./App";
 
+vi.mock("./hooks/useSession", () => ({
+  useSession: () => "ready",
+}));
+
 /** Default presenter state restored before each test. */
 const defaultPresenter = {
   page: 0,

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef } from "react";
 import SlideView from "./components/SlideView";
 import { usePresenter } from "./hooks/usePresenter";
+import { useSession } from "./hooks/useSession";
 import { slides } from "./slides/index";
 
 /** WebSocket URL derived from the current page origin. */
@@ -9,6 +10,7 @@ const wsUrl = (): string => location.origin.replace(/^http/, "ws") + "/ws";
 
 /** Root application component that renders all slides vertically and scrolls to the active page. */
 const App = (): ReactNode => {
+  const sessionStatus = useSession();
   const { page, viewerCount, pollStates, sendPollVote, sendPollUnvote, sendPollSwitch } =
     usePresenter(wsUrl());
 
@@ -67,6 +69,7 @@ const App = (): ReactNode => {
         >
           <SlideView
             page={i}
+            sessionStatus={sessionStatus}
             pollStates={pollStates}
             onPollVote={sendPollVote}
             onPollUnvote={sendPollUnvote}

--- a/front/src/components/SlideView.test.tsx
+++ b/front/src/components/SlideView.test.tsx
@@ -10,6 +10,7 @@ vi.mock("../slides/index", () => {
 
 /** Default poll props for SlideView tests. */
 const pollProps = {
+  sessionStatus: "ready" as const,
   pollStates: {},
   onPollVote: vi.fn(),
   onPollUnvote: vi.fn(),

--- a/front/src/components/SlideView.tsx
+++ b/front/src/components/SlideView.tsx
@@ -1,9 +1,11 @@
 import type { ReactNode } from "react";
 import { slides } from "../slides/index";
 import type { PollStateData } from "../hooks/usePresenter";
+import type { SessionStatus } from "../hooks/useSession";
 
-/** Props passed to each slide component providing access to all poll states and poll actions. */
+/** Props passed to each slide component providing access to session status, poll states, and poll actions. */
 export interface SlideProps {
+  sessionStatus: SessionStatus;
   pollStates: Partial<Record<string, PollStateData>>;
   onPollVote: (pollId: string, choice: string) => void;
   onPollUnvote: (pollId: string, choice: string) => void;
@@ -18,6 +20,7 @@ interface SlideViewProps extends SlideProps {
 /** Renders the slide component corresponding to the given page number. */
 const SlideView = ({
   page,
+  sessionStatus,
   pollStates,
   onPollVote,
   onPollUnvote,
@@ -45,6 +48,7 @@ const SlideView = ({
   return (
     <div role="region" aria-label="slide content" style={{ width: "100%", height: "100%" }}>
       <Slide
+        sessionStatus={sessionStatus}
         pollStates={pollStates}
         onPollVote={onPollVote}
         onPollUnvote={onPollUnvote}

--- a/front/src/hooks/useSession.test.ts
+++ b/front/src/hooks/useSession.test.ts
@@ -12,6 +12,13 @@ import { createSession, deleteSession } from "../api/client";
 const mockCreateSession = vi.mocked(createSession);
 const mockDeleteSession = vi.mocked(deleteSession);
 
+/** Flush all pending microtasks so async effects settle. */
+const flushMicrotasks = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
 beforeEach(() => {
   mockCreateSession.mockReset();
   mockDeleteSession.mockReset();
@@ -65,9 +72,8 @@ describe("useSession", () => {
 
     const { result } = renderHook(() => useSession());
 
-    await vi.waitFor(() => {
-      expect(result.current).toBe("retrying");
-    });
+    await flushMicrotasks();
+    expect(result.current).toBe("retrying");
     expect(mockCreateSession).toHaveBeenCalledOnce();
 
     await act(async () => {
@@ -88,9 +94,8 @@ describe("useSession", () => {
 
     renderHook(() => useSession());
 
-    await vi.waitFor(() => {
-      expect(mockCreateSession).toHaveBeenCalledOnce();
-    });
+    await flushMicrotasks();
+    expect(mockCreateSession).toHaveBeenCalledOnce();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
@@ -185,9 +190,8 @@ describe("useSession", () => {
 
     const { unmount } = renderHook(() => useSession());
 
-    await vi.waitFor(() => {
-      expect(mockCreateSession).toHaveBeenCalledOnce();
-    });
+    await flushMicrotasks();
+    expect(mockCreateSession).toHaveBeenCalledOnce();
 
     unmount();
 

--- a/front/src/hooks/useSession.test.ts
+++ b/front/src/hooks/useSession.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useSession } from "./useSession";
 
 vi.mock("../api/client", () => ({
@@ -23,12 +23,12 @@ afterEach(() => {
 });
 
 describe("useSession", () => {
-  it("creates session on mount and returns ready true", async () => {
+  it("starts with loading status and transitions to ready on success", async () => {
     const { result } = renderHook(() => useSession());
-    expect(result.current).toBe(false);
+    expect(result.current).toBe("loading");
 
     await waitFor(() => {
-      expect(result.current).toBe(true);
+      expect(result.current).toBe("ready");
     });
     expect(mockCreateSession).toHaveBeenCalledOnce();
   });
@@ -43,15 +43,82 @@ describe("useSession", () => {
     expect(mockCreateSession.mock.lastCall?.[0]).toBeInstanceOf(AbortSignal);
   });
 
-  it("does not set ready when createSession fails", async () => {
+  it("transitions to retrying when createSession fails", async () => {
     mockCreateSession.mockRejectedValue(new Error("network error"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result, unmount } = renderHook(() => useSession());
+
+    await waitFor(() => {
+      expect(result.current).toBe("retrying");
+    });
+
+    unmount();
+    spy.mockRestore();
+  });
+
+  it("retries after delay on failure", async () => {
+    vi.useFakeTimers();
+    mockCreateSession.mockRejectedValueOnce(new Error("network error"));
+    mockCreateSession.mockResolvedValueOnce(undefined);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const { result } = renderHook(() => useSession());
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
+      expect(result.current).toBe("retrying");
+    });
+    expect(mockCreateSession).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(result.current).toBe("ready");
+    expect(mockCreateSession).toHaveBeenCalledTimes(2);
+
+    spy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("uses exponential backoff with cap at 8 seconds", async () => {
+    vi.useFakeTimers();
+    mockCreateSession.mockRejectedValue(new Error("network error"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderHook(() => useSession());
+
+    await vi.waitFor(() => {
       expect(mockCreateSession).toHaveBeenCalledOnce();
     });
-    expect(result.current).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(mockCreateSession).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(mockCreateSession).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(mockCreateSession).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    expect(mockCreateSession).toHaveBeenCalledTimes(5);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    expect(mockCreateSession).toHaveBeenCalledTimes(6);
+
+    spy.mockRestore();
+    vi.useRealTimers();
   });
 
   it("logs non-abort errors to console.error", async () => {
@@ -59,12 +126,13 @@ describe("useSession", () => {
     mockCreateSession.mockRejectedValue(error);
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    renderHook(() => useSession());
+    const { unmount } = renderHook(() => useSession());
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith("Failed to create session", error);
     });
 
+    unmount();
     spy.mockRestore();
   });
 
@@ -86,6 +154,7 @@ describe("useSession", () => {
 
   it("does not call deleteSession when createSession fails and unmounts", async () => {
     mockCreateSession.mockRejectedValue(new Error("network error"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const { unmount } = renderHook(() => useSession());
 
@@ -95,16 +164,40 @@ describe("useSession", () => {
     unmount();
 
     expect(mockDeleteSession).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 
-  it("deletes session on unmount", async () => {
+  it("deletes session on unmount when ready", async () => {
     const { result, unmount } = renderHook(() => useSession());
 
     await waitFor(() => {
-      expect(result.current).toBe(true);
+      expect(result.current).toBe("ready");
     });
 
     unmount();
     expect(mockDeleteSession).toHaveBeenCalledWith();
+  });
+
+  it("cancels pending retry on unmount", async () => {
+    vi.useFakeTimers();
+    mockCreateSession.mockRejectedValueOnce(new Error("network error"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useSession());
+
+    await vi.waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledOnce();
+    });
+
+    unmount();
+
+    mockCreateSession.mockResolvedValueOnce(undefined);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledOnce();
+    spy.mockRestore();
+    vi.useRealTimers();
   });
 });

--- a/front/src/hooks/useSession.ts
+++ b/front/src/hooks/useSession.ts
@@ -1,37 +1,56 @@
 import { useEffect, useRef, useState } from "react";
 import { createSession, deleteSession } from "../api/client";
 
+/** Possible states of the session lifecycle. */
+export type SessionStatus = "loading" | "ready" | "retrying";
+
+/** Maximum retry delay in milliseconds. */
+const MAX_DELAY_MS = 8000;
+
 /**
- * Hook that creates a session on mount and attempts to delete it on unmount.
- * Returns whether the session is ready.
+ * Hook that creates a session on mount with automatic retry on failure.
+ * Returns the current session status. Cleans up the session on unmount.
  */
-export const useSession = (): boolean => {
-  const [ready, setReady] = useState(false);
+export const useSession = (): SessionStatus => {
+  const [status, setStatus] = useState<SessionStatus>("loading");
   const readyRef = useRef(false);
 
   useEffect(() => {
     const ac = new AbortController();
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    void (async () => {
+    const attempt = async (delay: number): Promise<void> => {
       try {
         await createSession(ac.signal);
         if (ac.signal.aborted) return;
         readyRef.current = true;
-        setReady(true);
+        setStatus("ready");
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (ac.signal.aborted) return;
         console.error("Failed to create session", err);
+        setStatus("retrying");
+        const nextDelay = Math.min(delay * 2, MAX_DELAY_MS);
+        retryTimeout = setTimeout(() => {
+          if (!ac.signal.aborted) {
+            void attempt(nextDelay);
+          }
+        }, delay);
       }
-    })();
+    };
+
+    void attempt(1000);
 
     return () => {
       ac.abort();
+      if (retryTimeout !== undefined) {
+        clearTimeout(retryTimeout);
+      }
       if (readyRef.current) {
         deleteSession();
       }
     };
   }, []);
 
-  return ready;
+  return status;
 };

--- a/front/src/slides/TerminalSlide.test.tsx
+++ b/front/src/slides/TerminalSlide.test.tsx
@@ -1,0 +1,88 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TerminalSlide } from "./TerminalSlide";
+import type { SessionStatus } from "../hooks/useSession";
+
+const mockWrite = vi.fn();
+const mockWriteln = vi.fn();
+
+vi.mock("../components/Terminal", () => ({
+  default: forwardRef((_: unknown, ref: React.Ref<unknown>) => {
+    useImperativeHandle(ref, () => ({ write: mockWrite, writeln: mockWriteln }));
+    return <div data-testid="terminal" />;
+  }),
+}));
+
+vi.mock("../hooks/useExecute", () => ({
+  useExecute: () => ({ run: vi.fn(), running: false }),
+}));
+
+beforeEach(() => {
+  mockWrite.mockClear();
+  mockWriteln.mockClear();
+});
+
+/** Default props for TerminalSlide tests. */
+const defaultProps = {
+  instruction: "Try a command",
+  commands: ["echo hello"],
+};
+
+/** Render helper that merges sessionStatus with default props. */
+const renderSlide = (sessionStatus: SessionStatus): ReturnType<typeof render> =>
+  render(<TerminalSlide sessionStatus={sessionStatus} {...defaultProps} />);
+
+describe("TerminalSlide", () => {
+  it("writes loading message to terminal when status is loading", () => {
+    renderSlide("loading");
+    expect(mockWriteln).toHaveBeenCalledWith("Connecting to runner...");
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("writes retrying message with yellow ANSI color when status is retrying", () => {
+    renderSlide("retrying");
+    expect(mockWriteln).toHaveBeenCalledWith("\x1b[33mConnection failed. Retrying...\x1b[0m");
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("writes prompt to terminal when status is ready", () => {
+    renderSlide("ready");
+    expect(mockWrite).toHaveBeenCalledWith("$ ");
+    expect(mockWriteln).not.toHaveBeenCalled();
+  });
+
+  it("renders instruction text", () => {
+    renderSlide("loading");
+    expect(screen.getByText("Try a command")).toBeDefined();
+  });
+
+  it("disables command input when not ready", () => {
+    renderSlide("loading");
+    const input = screen.getByPlaceholderText("echo hello");
+    expect(input).toBeDisabled();
+  });
+
+  it("enables command input when ready", () => {
+    renderSlide("ready");
+    const input = screen.getByPlaceholderText("echo hello");
+    expect(input).not.toBeDisabled();
+  });
+
+  it("updates terminal message when status transitions", () => {
+    const { rerender } = render(<TerminalSlide sessionStatus="loading" {...defaultProps} />);
+    expect(mockWriteln).toHaveBeenCalledWith("Connecting to runner...");
+
+    mockWrite.mockClear();
+    mockWriteln.mockClear();
+
+    rerender(<TerminalSlide sessionStatus="retrying" {...defaultProps} />);
+    expect(mockWriteln).toHaveBeenCalledWith("\x1b[33mConnection failed. Retrying...\x1b[0m");
+
+    mockWrite.mockClear();
+    mockWriteln.mockClear();
+
+    rerender(<TerminalSlide sessionStatus="ready" {...defaultProps} />);
+    expect(mockWrite).toHaveBeenCalledWith("$ ");
+  });
+});

--- a/front/src/slides/TerminalSlide.tsx
+++ b/front/src/slides/TerminalSlide.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from "react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import Terminal, { type TerminalHandle } from "../components/Terminal";
 import CommandInput from "../components/CommandInput";
-import { useSession } from "../hooks/useSession";
 import { useExecute } from "../hooks/useExecute";
+import type { SessionStatus } from "../hooks/useSession";
 
 /** Props for the TerminalSlide component. */
 interface TerminalSlideProps {
+  /** Current session connection status. */
+  sessionStatus: SessionStatus;
   /** Instructional text displayed above the terminal. */
   instruction: string;
   /** Commands shown as placeholder hints in the input field. */
@@ -14,11 +16,28 @@ interface TerminalSlideProps {
 }
 
 /** Slide component with an embedded terminal and command input. */
-export const TerminalSlide = ({ instruction, commands }: TerminalSlideProps): ReactNode => {
-  const ready = useSession();
+export const TerminalSlide = ({
+  sessionStatus,
+  instruction,
+  commands,
+}: TerminalSlideProps): ReactNode => {
+  const ready = sessionStatus === "ready";
   const terminalRef = useRef<TerminalHandle>(null);
   const { run, running } = useExecute(ready, terminalRef);
   const placeholder = commands[0] ?? "";
+
+  /** Write session status messages to the terminal. */
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term) return;
+    if (sessionStatus === "loading") {
+      term.writeln("Connecting to runner...");
+    } else if (sessionStatus === "retrying") {
+      term.writeln("\x1b[33mConnection failed. Retrying...\x1b[0m");
+    } else if (sessionStatus === "ready") {
+      term.write("$ ");
+    }
+  }, [sessionStatus]);
 
   return (
     <div

--- a/front/src/slides/index.tsx
+++ b/front/src/slides/index.tsx
@@ -14,7 +14,13 @@ const buildSlide = (data: (typeof slideData)[number]): ComponentType<SlideProps>
     case "text":
       return () => <TextSlide lines={data.lines} />;
     case "terminal":
-      return () => <TerminalSlide instruction={data.instruction} commands={data.commands} />;
+      return (props: SlideProps) => (
+        <TerminalSlide
+          sessionStatus={props.sessionStatus}
+          instruction={data.instruction}
+          commands={data.commands}
+        />
+      );
     case "poll":
       return (props: SlideProps) => (
         <PollSlide


### PR DESCRIPTION
## Summary
- Replace boolean `useSession` return with `SessionStatus` type (`"loading" | "ready" | "retrying"`) and add exponential backoff retry on failure (1s, 2s, 4s, 8s cap)
- Thread `sessionStatus` through `SlideProps` so slides receive session state from `App` instead of calling `useSession` themselves
- Display connection status in Slide0's terminal: "Connecting to runner..." on load, yellow "Connection failed. Retrying..." on retry, "$ " prompt on ready

## Test plan
- [x] All 157 tests pass (`pnpm vp test`)
- [ ] Manual: start with runner down → terminal shows "Connecting..." then "Retrying..."
- [ ] Manual: start runner → terminal shows "$ " prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション状態の表示を拡張し、「ロード中」「接続完了」「再試行中」の3つのステータスを追加
  * セッション接続失敗時に自動再試行機能を実装（指数バックオフで最大8秒まで）
  * ターミナルに接続状態を示すメッセージを動的に表示

* **テスト**
  * 新しいセッション状態モデルに対応したテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->