### PR TITLE
feat: reduce AcquireIdle contention with batch query and shuffle

### DIFF
--- a/broker/store/dynamo.go
+++ b/broker/store/dynamo.go
@@ -84,8 +84,12 @@ func (r *DynamoRepository) BucketCount() int {
 	return bucketCount
 }
 
+// idleQueryLimit はバケットクエリで一度に取得する idle runner の最大数。
+// 複数件取得してランダムに選ぶことで同一 runner への競合を分散する。
+const idleQueryLimit = 20
+
 // AcquireIdle は指定バケットから idle runner を1台確保し session を紐づける。
-// バケット内で競合した場合は同じバケット内で再試行する。
+// バケット内の候補を最大 idleQueryLimit 件取得しランダムな順序で試行する。
 // GSI は eventually consistent なため、assignSession 済みの runner が再度返される場合がある。
 // tried 集合で同一 runner の無限リトライを防止する。
 // sessionID の一意性は呼び出し側が保証する。
@@ -93,32 +97,42 @@ func (r *DynamoRepository) AcquireIdle(ctx context.Context, sessionID string, bu
 	bucketKey := fmt.Sprintf("bucket-%d", bucket)
 	tried := map[string]struct{}{}
 	for {
-		runner, err := r.queryIdleBucket(ctx, bucketKey)
+		runners, err := r.queryIdleBucket(ctx, bucketKey)
 		if err != nil {
 			return nil, err
 		}
-		if runner == nil {
+		if len(runners) == 0 {
 			return nil, ErrNoIdleRunner
 		}
-		if _, seen := tried[runner.RunnerID]; seen {
+		rand.Shuffle(len(runners), func(i, j int) {
+			runners[i], runners[j] = runners[j], runners[i]
+		})
+		progressed := false
+		for i := range runners {
+			runner := &runners[i]
+			if _, seen := tried[runner.RunnerID]; seen {
+				continue
+			}
+			tried[runner.RunnerID] = struct{}{}
+			progressed = true
+			err = r.assignSession(ctx, runner.RunnerID, sessionID)
+			if err == nil {
+				runner.CurrentSessionID = sessionID
+				runner.IdleBucket = ""
+				return runner, nil
+			}
+			if !errors.Is(err, ErrConditionFailed) {
+				return nil, err
+			}
+		}
+		if !progressed {
 			return nil, ErrNoIdleRunner
 		}
-		tried[runner.RunnerID] = struct{}{}
-		err = r.assignSession(ctx, runner.RunnerID, sessionID)
-		if err == nil {
-			runner.CurrentSessionID = sessionID
-			runner.IdleBucket = ""
-			return runner, nil
-		}
-		if errors.Is(err, ErrConditionFailed) {
-			continue
-		}
-		return nil, err
 	}
 }
 
-// queryIdleBucket は指定バケットから idle runner を1台取得する。
-func (r *DynamoRepository) queryIdleBucket(ctx context.Context, bucket string) (*model.Runner, error) {
+// queryIdleBucket は指定バケットから idle runner を最大 idleQueryLimit 件取得する。
+func (r *DynamoRepository) queryIdleBucket(ctx context.Context, bucket string) ([]model.Runner, error) {
 	out, err := r.client.Query(ctx, &dynamodb.QueryInput{
 		TableName:              &r.tableName,
 		IndexName:              aws.String("idle-index"),
@@ -126,19 +140,20 @@ func (r *DynamoRepository) queryIdleBucket(ctx context.Context, bucket string) (
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":b": &types.AttributeValueMemberS{Value: bucket},
 		},
-		Limit: aws.Int32(1),
+		Limit: aws.Int32(idleQueryLimit),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("query idle-index: %w", err)
 	}
-	if len(out.Items) == 0 {
-		return nil, nil
+	runners := make([]model.Runner, 0, len(out.Items))
+	for _, item := range out.Items {
+		var runner model.Runner
+		if err := attributevalue.UnmarshalMap(item, &runner); err != nil {
+			return nil, fmt.Errorf("unmarshal runner: %w", err)
+		}
+		runners = append(runners, runner)
 	}
-	var runner model.Runner
-	if err := attributevalue.UnmarshalMap(out.Items[0], &runner); err != nil {
-		return nil, fmt.Errorf("unmarshal runner: %w", err)
-	}
-	return &runner, nil
+	return runners, nil
 }
 
 // assignSession は runner に session を紐づけ idle から busy に遷移させる。idleBucket が存在する場合のみ成功する。

--- a/broker/store/dynamo_test.go
+++ b/broker/store/dynamo_test.go
@@ -343,7 +343,8 @@ func TestAcquireIdle_RetryWithinBatch(t *testing.T) {
 		updateItemFn: func(_ context.Context, params *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
 			updateCount++
 			rid := params.Key["runnerId"].(*types.AttributeValueMemberS).Value
-			if rid == "r1" {
+			// r2 のみ成功可能。シャッフル順序に関係なく r1 は必ず競合する。
+			if rid != "r2" {
 				return nil, &types.ConditionalCheckFailedException{Message: aws.String("conflict")}
 			}
 			return &dynamodb.UpdateItemOutput{}, nil
@@ -361,8 +362,8 @@ func TestAcquireIdle_RetryWithinBatch(t *testing.T) {
 	if queryCount != 1 {
 		t.Errorf("query count = %d, want 1", queryCount)
 	}
-	if updateCount != 2 {
-		t.Errorf("update count = %d, want 2", updateCount)
+	if updateCount < 1 || updateCount > 2 {
+		t.Errorf("update count = %d, want 1 or 2", updateCount)
 	}
 }
 
@@ -485,7 +486,7 @@ func TestAcquireIdle_UnmarshalError(t *testing.T) {
 func TestAcquireIdle_ShuffleDistribution(t *testing.T) {
 	t.Parallel()
 	assigned := map[string]int{}
-	for range 100 {
+	for range 1000 {
 		mock := &mockDynamoDBAPI{
 			queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
 				return &dynamodb.QueryOutput{

--- a/broker/store/dynamo_test.go
+++ b/broker/store/dynamo_test.go
@@ -247,6 +247,9 @@ func TestAcquireIdle_Success(t *testing.T) {
 			if bucket != "bucket-2" {
 				t.Errorf("bucket = %q, want %q", bucket, "bucket-2")
 			}
+			if *params.Limit != idleQueryLimit {
+				t.Errorf("Limit = %d, want %d", *params.Limit, idleQueryLimit)
+			}
 			return &dynamodb.QueryOutput{
 				Items: []map[string]types.AttributeValue{
 					{
@@ -265,9 +268,6 @@ func TestAcquireIdle_Success(t *testing.T) {
 	runner, err := repo.AcquireIdle(context.Background(), "sess-1", 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if runner.RunnerID != "r1" {
-		t.Errorf("runnerID = %q, want %q", runner.RunnerID, "r1")
 	}
 	if runner.CurrentSessionID != "sess-1" {
 		t.Errorf("currentSessionId = %q, want %q", runner.CurrentSessionID, "sess-1")
@@ -318,8 +318,8 @@ func assertBucket(t *testing.T, params *dynamodb.QueryInput, want string) {
 	}
 }
 
-// TestAcquireIdle_RetryWithinBucket は同一バケット内で競合時にリトライすることを検証する。
-func TestAcquireIdle_RetryWithinBucket(t *testing.T) {
+// TestAcquireIdle_RetryWithinBatch は同一バッチ内で競合時に次の候補を試行することを検証する。
+func TestAcquireIdle_RetryWithinBatch(t *testing.T) {
 	t.Parallel()
 	queryCount := 0
 	updateCount := 0
@@ -327,21 +327,23 @@ func TestAcquireIdle_RetryWithinBucket(t *testing.T) {
 		queryFn: func(_ context.Context, params *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
 			assertBucket(t, params, "bucket-0")
 			queryCount++
-			if queryCount <= 2 {
-				return &dynamodb.QueryOutput{
-					Items: []map[string]types.AttributeValue{
-						{
-							"runnerId":   &types.AttributeValueMemberS{Value: "r" + itoa(queryCount)},
-							"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
-						},
+			return &dynamodb.QueryOutput{
+				Items: []map[string]types.AttributeValue{
+					{
+						"runnerId":   &types.AttributeValueMemberS{Value: "r1"},
+						"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
 					},
-				}, nil
-			}
-			return &dynamodb.QueryOutput{Items: nil}, nil
+					{
+						"runnerId":   &types.AttributeValueMemberS{Value: "r2"},
+						"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
+					},
+				},
+			}, nil
 		},
-		updateItemFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+		updateItemFn: func(_ context.Context, params *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
 			updateCount++
-			if updateCount == 1 {
+			rid := params.Key["runnerId"].(*types.AttributeValueMemberS).Value
+			if rid == "r1" {
 				return nil, &types.ConditionalCheckFailedException{Message: aws.String("conflict")}
 			}
 			return &dynamodb.UpdateItemOutput{}, nil
@@ -356,16 +358,16 @@ func TestAcquireIdle_RetryWithinBucket(t *testing.T) {
 	if runner.RunnerID != "r2" {
 		t.Errorf("runnerID = %q, want %q", runner.RunnerID, "r2")
 	}
-	if queryCount != 2 {
-		t.Errorf("query count = %d, want 2", queryCount)
+	if queryCount != 1 {
+		t.Errorf("query count = %d, want 1", queryCount)
 	}
 	if updateCount != 2 {
 		t.Errorf("update count = %d, want 2", updateCount)
 	}
 }
 
-// TestAcquireIdle_ConflictThenBucketEmpty はバケット内で競合後にバケットが空になり ErrNoIdleRunner を返すことを検証する。
-func TestAcquireIdle_ConflictThenBucketEmpty(t *testing.T) {
+// TestAcquireIdle_AllConflictThenEmpty はバッチ内全候補が競合し次クエリが空の場合に ErrNoIdleRunner を返すことを検証する。
+func TestAcquireIdle_AllConflictThenEmpty(t *testing.T) {
 	t.Parallel()
 	queryCount := 0
 	mock := &mockDynamoDBAPI{
@@ -427,7 +429,7 @@ func TestAcquireIdle_StaleGSI(t *testing.T) {
 		t.Fatalf("expected ErrNoIdleRunner, got: %v", err)
 	}
 	if queryCount != 2 {
-		t.Errorf("query count = %d, want 2 (initial + stale detection)", queryCount)
+		t.Errorf("query count = %d, want 2 (initial batch tried + stale detection)", queryCount)
 	}
 }
 
@@ -476,6 +478,48 @@ func TestAcquireIdle_UnmarshalError(t *testing.T) {
 	_, err := repo.AcquireIdle(context.Background(), "sess-1", 0)
 	if err == nil {
 		t.Fatal("expected unmarshal error")
+	}
+}
+
+// TestAcquireIdle_ShuffleDistribution はバッチ内の候補がランダムに選ばれることを検証する。
+func TestAcquireIdle_ShuffleDistribution(t *testing.T) {
+	t.Parallel()
+	assigned := map[string]int{}
+	for range 100 {
+		mock := &mockDynamoDBAPI{
+			queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{
+					Items: []map[string]types.AttributeValue{
+						{
+							"runnerId":   &types.AttributeValueMemberS{Value: "r1"},
+							"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
+						},
+						{
+							"runnerId":   &types.AttributeValueMemberS{Value: "r2"},
+							"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
+						},
+						{
+							"runnerId":   &types.AttributeValueMemberS{Value: "r3"},
+							"idleBucket": &types.AttributeValueMemberS{Value: "bucket-0"},
+						},
+					},
+				}, nil
+			},
+			updateItemFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+				return &dynamodb.UpdateItemOutput{}, nil
+			},
+		}
+		repo := NewDynamoRepository(mock, "t")
+		runner, err := repo.AcquireIdle(context.Background(), "sess-1", 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assigned[runner.RunnerID]++
+	}
+	for _, id := range []string{"r1", "r2", "r3"} {
+		if assigned[id] == 0 {
+			t.Errorf("runner %q was never selected in 100 iterations", id)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `queryIdleBucket` を `Limit: 1` から `Limit: 20` に変更し、バケット内の idle runner を最大20件一括取得
- 取得した候補をランダムにシャッフルしてから `assignSession` を試行
- 同じバケットに同時アクセスする VU が異なる runner を取りに行くため、DynamoDB の条件付き更新の競合が大幅に減少

### Before
250同時セッション作成時、同一バケットの全VUが同じ runner（GSI先頭1件）を取り合い → 大量の ConditionalCheckFailedException → レイテンシ増加・503エラー

### After
バッチ取得+シャッフルにより各VUが異なる runner を試行 → 競合減少 → レイテンシ改善・503エラー減少

## Test plan

- [x] 全ユニットテスト PASS（カバレッジ100%）
- [ ] ステージング環境で250VU負荷試験を再実行し、503エラー数とレイテンシを比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * アイドルランナーの獲得処理を改善し、複数の候補から最適なランナーを選択するようにしました。

* **Tests**
  * アイドルランナー獲得機能の新しい動作を検証するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->