### PR TITLE
feat: auto-generate presenter sequence from slideData

### DIFF
--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -1,6 +1,57 @@
 import { describe, expect, it } from "vitest";
 import { Action } from "../api/presenter";
-import { defaultPolls, defaultSequence, type PresenterStep } from "./sequence";
+import { buildSequence, defaultPolls, defaultSequence, type PresenterStep } from "./sequence";
+import { slideData } from "../slides/slideData";
+
+describe("buildSequence", () => {
+  /** Verify that an empty input produces an empty sequence. */
+  it("returns empty array for empty input", () => {
+    expect(buildSequence([])).toEqual([]);
+  });
+
+  /** Verify that non-terminal slides produce only SlideSync steps. */
+  it("generates SlideSync for non-terminal slides", () => {
+    const data = [{ type: "title" }, { type: "text" }, { type: "poll" }];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.SlideSync, page: 1 },
+      { type: Action.SlideSync, page: 2 },
+    ]);
+  });
+
+  /** Verify that terminal slides produce SlideSync followed by HandsOn. */
+  it("inserts HandsOn step after terminal slides", () => {
+    const data = [
+      { type: "text" },
+      { type: "terminal", instruction: "Run it", commands: ["echo hello", "date"] },
+      { type: "text" },
+    ];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.SlideSync, page: 1 },
+      { type: Action.HandsOn, instruction: "Run it", placeholder: "echo hello\ndate" },
+      { type: Action.SlideSync, page: 2 },
+    ]);
+  });
+
+  /** Verify that terminal slides with empty instruction and commands produce correct defaults. */
+  it("handles terminal slide with empty instruction and commands", () => {
+    const data = [{ type: "terminal", instruction: "", commands: [] }];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.HandsOn, instruction: "", placeholder: "" },
+    ]);
+  });
+
+  /** Verify that terminal slides without optional fields default gracefully. */
+  it("handles terminal slide with missing optional fields", () => {
+    const data = [{ type: "terminal" }];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.HandsOn, instruction: "", placeholder: "" },
+    ]);
+  });
+});
 
 describe("defaultSequence", () => {
   /** Verify that the default sequence is a non-empty array. */
@@ -15,14 +66,21 @@ describe("defaultSequence", () => {
     expect(first).toEqual({ type: Action.SlideSync, page: 0 });
   });
 
-  /** Verify that the default sequence contains 3 slide_sync steps. */
-  it("contains 3 steps in the expected order", () => {
-    expect(defaultSequence).toHaveLength(3);
-    expect(defaultSequence).toEqual([
-      { type: Action.SlideSync, page: 0 },
-      { type: Action.SlideSync, page: 1 },
-      { type: Action.SlideSync, page: 2 },
-    ]);
+  /** Verify that the sequence length matches slideData count plus HandsOn steps for terminal slides. */
+  it("has correct length based on slideData", () => {
+    const terminalCount = slideData.filter((s) => s.type === "terminal").length;
+    expect(defaultSequence).toHaveLength(slideData.length + terminalCount);
+  });
+
+  /** Verify that every slide page index appears as a SlideSync step. */
+  it("contains a SlideSync step for every slide", () => {
+    const slideSyncPages = defaultSequence
+      .filter(
+        (s): s is { type: typeof Action.SlideSync; page: number } => s.type === Action.SlideSync,
+      )
+      .map((s) => s.page);
+    const expectedPages = slideData.map((_, i) => i);
+    expect(slideSyncPages).toEqual(expectedPages);
   });
 });
 

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -1,4 +1,5 @@
 import { Action, type HandsOnPayload, type SlideSyncPayload } from "../api/presenter";
+import { slideData } from "../slides/slideData";
 
 /** Poll open payload used only in presenter steps to initialize a poll for viewers. */
 export type PollOpenPayload = {
@@ -14,12 +15,27 @@ export type PollOpenPayload = {
  */
 export type PresenterStep = SlideSyncPayload | HandsOnPayload;
 
-/** Default presentation sequence used by the presenter control panel. */
-export const defaultSequence: PresenterStep[] = [
-  { type: Action.SlideSync, page: 0 },
-  { type: Action.SlideSync, page: 1 },
-  { type: Action.SlideSync, page: 2 },
-];
+/** Generates the presentation sequence from slideData, inserting HandsOn steps after terminal slides. */
+export const buildSequence = (
+  data: ReadonlyArray<{ type: string; instruction?: string; commands?: string[] }>,
+): PresenterStep[] => {
+  const steps: PresenterStep[] = [];
+  for (let i = 0; i < data.length; i++) {
+    steps.push({ type: Action.SlideSync, page: i });
+    const slide = data[i];
+    if (slide.type === "terminal") {
+      steps.push({
+        type: Action.HandsOn,
+        instruction: slide.instruction ?? "",
+        placeholder: (slide.commands ?? []).join("\n"),
+      });
+    }
+  }
+  return steps;
+};
+
+/** Default presentation sequence generated from slideData. */
+export const defaultSequence: PresenterStep[] = buildSequence(slideData);
 
 /** Default poll list reserved for future use. */
 export const defaultPolls: PollOpenPayload[] = [];


### PR DESCRIPTION
## Summary
- Auto-generate `defaultSequence` from `slideData` instead of hardcoding 3 slides
- `buildSequence` maps each slide to a `SlideSync` step, and inserts a `HandsOn` step after `terminal` slides
- All 50 slides now appear in the presenter panel

## Test plan
- [x] Unit tests for `buildSequence` with empty, non-terminal, terminal, and edge cases
- [x] `defaultSequence` tests verify length and page coverage against `slideData`
- [x] All 170 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * スライドシーケンス生成機能のテストカバレッジを拡大しました。空入力、ターミナルスライド処理、デフォルト値の動作を含む複数のシナリオに対応しています。

* **Improvements**
  * スライドデータに基づいてシーケンスを動的に生成する仕様に変更しました。ターミナルスライドの後に追加ステップが自動的に挿入されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->