### PR TITLE
Add poll_open WebSocket handler to broadcast polls to all viewers

### DIFF
--- a/front/src/api/presenter.ts
+++ b/front/src/api/presenter.ts
@@ -23,6 +23,7 @@ export const ServerMessageType = {
 
 /** Discriminant values for client-to-server presenter messages. */
 export const ClientMessageType = {
+  PollOpen: Action.PollOpen,
   PollGet: Action.PollGet,
   PollVote: Action.PollVote,
   PollUnvote: Action.PollUnvote,

--- a/front/src/hooks/usePresenter.ts
+++ b/front/src/hooks/usePresenter.ts
@@ -28,6 +28,7 @@ export interface UsePresenterResult {
   pollStates: Partial<Record<string, PollStateData>>;
   sendSlideSync: (page: number) => void;
   sendHandsOn: (instruction: string, placeholder: string) => void;
+  sendPollOpen: (pollId: string, options: string[], maxChoices: number) => void;
   sendPollGet: (pollId: string, options: string[], maxChoices: number) => void;
   sendPollVote: (pollId: string, choice: string) => void;
   sendPollUnvote: (pollId: string, choice: string) => void;
@@ -149,6 +150,22 @@ export const usePresenter = (
     );
   }, []);
 
+  /** Send a poll_open message to start a poll and broadcast it to all viewers. */
+  const sendPollOpen = useCallback(
+    (pollId: string, options: string[], maxChoices: number): void => {
+      wsRef.current?.send(
+        JSON.stringify({
+          action: "message",
+          type: ClientMessageType.PollOpen,
+          pollId,
+          options,
+          maxChoices,
+        }),
+      );
+    },
+    [],
+  );
+
   /** Send a poll_get message to initialize or retrieve a poll. */
   const sendPollGet = useCallback((pollId: string, options: string[], maxChoices: number): void => {
     wsRef.current?.send(
@@ -192,6 +209,7 @@ export const usePresenter = (
     pollStates,
     sendSlideSync,
     sendHandsOn,
+    sendPollOpen,
     sendPollGet,
     sendPollVote,
     sendPollUnvote,

--- a/front/src/presenter/PresenterPanel.test.tsx
+++ b/front/src/presenter/PresenterPanel.test.tsx
@@ -18,9 +18,11 @@ vi.mock("./sequence", async () => {
 const createProps = (): PresenterPanelProps & {
   sendSlideSync: Mock;
   sendHandsOn: Mock;
+  sendPollOpen: Mock;
 } => ({
   sendSlideSync: vi.fn(),
   sendHandsOn: vi.fn(),
+  sendPollOpen: vi.fn(),
   viewerCount: 0,
 });
 

--- a/front/src/presenter/PresenterPanel.test.tsx
+++ b/front/src/presenter/PresenterPanel.test.tsx
@@ -10,7 +10,6 @@ vi.mock("./sequence", async () => {
       { type: Action.HandsOn, instruction: "Run echo", placeholder: "echo hello" },
       { type: Action.SlideSync, page: 1 },
     ],
-    defaultPolls: [],
   };
 });
 

--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -8,6 +8,8 @@ export interface PresenterPanelProps {
   sendSlideSync: (page: number) => void;
   /** Sends a hands_on message with instruction and placeholder text. */
   sendHandsOn: (instruction: string, placeholder: string) => void;
+  /** Sends a poll_open message to start a poll for viewers. */
+  sendPollOpen: (pollId: string, options: string[], maxChoices: number) => void;
   /** Number of currently connected viewers. */
   viewerCount: number;
 }
@@ -19,6 +21,8 @@ const describeStep = (step: PresenterStep): string => {
       return `Slide ${step.page}`;
     case Action.HandsOn:
       return `Hands-on: ${step.instruction}`;
+    case Action.PollOpen:
+      return `Poll: ${step.pollId}`;
   }
 };
 
@@ -26,6 +30,7 @@ const describeStep = (step: PresenterStep): string => {
 export const PresenterPanel = ({
   sendSlideSync,
   sendHandsOn,
+  sendPollOpen,
   viewerCount,
 }: PresenterPanelProps): ReactNode => {
   const sequence = defaultSequence;
@@ -42,9 +47,12 @@ export const PresenterPanel = ({
         case Action.HandsOn:
           sendHandsOn(step.instruction, step.placeholder);
           break;
+        case Action.PollOpen:
+          sendPollOpen(step.pollId, step.options, step.maxChoices);
+          break;
       }
     },
-    [sendSlideSync, sendHandsOn],
+    [sendSlideSync, sendHandsOn, sendPollOpen],
   );
 
   /** Navigates to a specific step index. */

--- a/front/src/presenter/main.tsx
+++ b/front/src/presenter/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from "react-dom/client";
 import { usePresenter } from "../hooks/usePresenter";
 import { LoginForm } from "./LoginForm";
 import { PresenterPanel } from "./PresenterPanel";
-import { defaultPolls } from "./sequence";
 
 /** WebSocket URL derived from the current page origin. */
 const wsUrl = (): string => location.origin.replace(/^http/, "ws") + "/ws";
@@ -44,19 +43,13 @@ const PresenterApp = (): ReactNode => {
 
 /** Inner component rendered after login that connects the usePresenter hook to the PresenterPanel. */
 const PresenterAppInner = (): ReactNode => {
-  const { viewerCount, sendSlideSync, sendHandsOn, sendPollGet } = usePresenter(wsUrl());
-
-  /** Send all poll definitions on mount to initialize polls. */
-  useEffect((): void => {
-    for (const poll of defaultPolls) {
-      sendPollGet(poll.pollId, poll.options, poll.maxChoices);
-    }
-  }, [sendPollGet]);
+  const { viewerCount, sendSlideSync, sendHandsOn, sendPollOpen } = usePresenter(wsUrl());
 
   return (
     <PresenterPanel
       sendSlideSync={sendSlideSync}
       sendHandsOn={sendHandsOn}
+      sendPollOpen={sendPollOpen}
       viewerCount={viewerCount}
     />
   );

--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -108,15 +108,32 @@ describe("PresenterStep discriminated union", () => {
     }
   });
 
+  /** Verify that a poll_open step carries pollId, options, and maxChoices properties. */
+  it("allows poll_open with pollId, options, and maxChoices", () => {
+    const step: PresenterStep = {
+      type: Action.PollOpen,
+      pollId: "q1",
+      options: ["A", "B"],
+      maxChoices: 1,
+    };
+    expect(step.type).toBe(Action.PollOpen);
+    if (step.type === Action.PollOpen) {
+      expect(step.pollId).toBe("q1");
+      expect(step.options).toEqual(["A", "B"]);
+      expect(step.maxChoices).toBe(1);
+    }
+  });
+
   /** Verify that all step types are present in the expected order. */
   it("collects expected ordered types", () => {
     const steps: PresenterStep[] = [
       { type: Action.SlideSync, page: 1 },
       { type: Action.HandsOn, instruction: "do it", placeholder: "cmd" },
+      { type: Action.PollOpen, pollId: "q1", options: ["A"], maxChoices: 1 },
     ];
 
     const types = steps.map((s) => s.type);
-    expect(types).toEqual([Action.SlideSync, Action.HandsOn]);
+    expect(types).toEqual([Action.SlideSync, Action.HandsOn, Action.PollOpen]);
   });
 });
 

--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Action } from "../api/presenter";
-import { buildSequence, defaultPolls, defaultSequence, type PresenterStep } from "./sequence";
+import { buildSequence, defaultSequence, type PresenterStep } from "./sequence";
 import { slideData } from "../slides/slideData";
 
 describe("buildSequence", () => {
@@ -9,13 +9,36 @@ describe("buildSequence", () => {
     expect(buildSequence([])).toEqual([]);
   });
 
-  /** Verify that non-terminal slides produce only SlideSync steps. */
+  /** Verify that non-terminal, non-poll slides produce only SlideSync steps. */
   it("generates SlideSync for non-terminal slides", () => {
-    const data = [{ type: "title" }, { type: "text" }, { type: "poll" }];
+    const data = [{ type: "title" }, { type: "text" }];
     expect(buildSequence(data)).toEqual([
       { type: Action.SlideSync, page: 0 },
       { type: Action.SlideSync, page: 1 },
+    ]);
+  });
+
+  /** Verify that poll slides produce SlideSync followed by PollOpen. */
+  it("inserts PollOpen step after poll slides", () => {
+    const data = [
+      { type: "text" },
+      { type: "poll", pollId: "q1", options: ["A", "B"] },
+      { type: "text" },
+    ];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.SlideSync, page: 1 },
+      { type: Action.PollOpen, pollId: "q1", options: ["A", "B"], maxChoices: 1 },
       { type: Action.SlideSync, page: 2 },
+    ]);
+  });
+
+  /** Verify that poll slides without pollId or options are skipped. */
+  it("skips PollOpen for poll slides missing pollId or options", () => {
+    const data = [{ type: "poll" }, { type: "poll", pollId: "q1" }];
+    expect(buildSequence(data)).toEqual([
+      { type: Action.SlideSync, page: 0 },
+      { type: Action.SlideSync, page: 1 },
     ]);
   });
 
@@ -66,10 +89,11 @@ describe("defaultSequence", () => {
     expect(first).toEqual({ type: Action.SlideSync, page: 0 });
   });
 
-  /** Verify that the sequence length matches slideData count plus HandsOn steps for terminal slides. */
+  /** Verify that the sequence length matches slideData count plus HandsOn and PollOpen steps. */
   it("has correct length based on slideData", () => {
     const terminalCount = slideData.filter((s) => s.type === "terminal").length;
-    expect(defaultSequence).toHaveLength(slideData.length + terminalCount);
+    const pollCount = slideData.filter((s) => s.type === "poll").length;
+    expect(defaultSequence).toHaveLength(slideData.length + terminalCount + pollCount);
   });
 
   /** Verify that every slide page index appears as a SlideSync step. */
@@ -134,12 +158,5 @@ describe("PresenterStep discriminated union", () => {
 
     const types = steps.map((s) => s.type);
     expect(types).toEqual([Action.SlideSync, Action.HandsOn, Action.PollOpen]);
-  });
-});
-
-describe("defaultPolls", () => {
-  /** Verify that the default polls list is an empty array. */
-  it("is an empty array", () => {
-    expect(defaultPolls).toEqual([]);
   });
 });

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -15,10 +15,17 @@ export type PollOpenPayload = {
  */
 export type PresenterStep = SlideSyncPayload | HandsOnPayload | PollOpenPayload;
 
-/** Generates the presentation sequence from slideData, inserting HandsOn steps after terminal slides. */
-export const buildSequence = (
-  data: ReadonlyArray<{ type: string; instruction?: string; commands?: string[] }>,
-): PresenterStep[] => {
+/** Input shape accepted by buildSequence covering terminal and poll slides. */
+type BuildSequenceInput = ReadonlyArray<{
+  type: string;
+  instruction?: string;
+  commands?: string[];
+  pollId?: string;
+  options?: string[];
+}>;
+
+/** Generates the presentation sequence from slideData, inserting HandsOn steps after terminal slides and PollOpen steps after poll slides. */
+export const buildSequence = (data: BuildSequenceInput): PresenterStep[] => {
   const steps: PresenterStep[] = [];
   for (let i = 0; i < data.length; i++) {
     steps.push({ type: Action.SlideSync, page: i });
@@ -30,12 +37,17 @@ export const buildSequence = (
         placeholder: (slide.commands ?? []).join("\n"),
       });
     }
+    if (slide.type === "poll" && slide.pollId && slide.options) {
+      steps.push({
+        type: Action.PollOpen,
+        pollId: slide.pollId,
+        options: slide.options,
+        maxChoices: 1,
+      });
+    }
   }
   return steps;
 };
 
 /** Default presentation sequence generated from slideData. */
 export const defaultSequence: PresenterStep[] = buildSequence(slideData);
-
-/** Default poll list reserved for future use. */
-export const defaultPolls: PollOpenPayload[] = [];

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -13,7 +13,7 @@ export type PollOpenPayload = {
  * Discriminated union type representing a single display-mode step in the presentation sequence.
  * SlideSyncPayload and HandsOnPayload are shared with server-to-client message types.
  */
-export type PresenterStep = SlideSyncPayload | HandsOnPayload;
+export type PresenterStep = SlideSyncPayload | HandsOnPayload | PollOpenPayload;
 
 /** Generates the presentation sequence from slideData, inserting HandsOn steps after terminal slides. */
 export const buildSequence = (

--- a/presenter/cmd/message/main.go
+++ b/presenter/cmd/message/main.go
@@ -190,6 +190,8 @@ func (h *messageHandler) handle(ctx context.Context, req events.APIGatewayWebsoc
 		return h.handleViewerCount(ctx, connectionID, deps)
 	case "get_state":
 		return h.handleGetState(ctx, connectionID, deps)
+	case "poll_open":
+		return h.handlePollOpen(ctx, connectionID, msg, deps)
 	case "poll_get":
 		return h.handlePollGet(ctx, connectionID, msg, deps)
 	case "poll_vote":
@@ -251,6 +253,29 @@ func (h *messageHandler) handleGetState(ctx context.Context, connectionID string
 	}
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+// handlePollOpen はアンケート開始メッセージを処理する。presenter のみ実行可能。
+// アンケートを初期化し全接続に poll_state をブロードキャストする。
+func (h *messageHandler) handlePollOpen(ctx context.Context, connectionID string, msg incomingMessage, deps handleDeps) (events.APIGatewayProxyResponse, error) {
+	if msg.PollID == "" || len(msg.Options) == 0 || msg.MaxChoices == 0 {
+		return h.sendError(ctx, connectionID, "pollId, options, and maxChoices are required", deps)
+	}
+
+	conn, err := h.connGetter.Get(ctx, room, connectionID)
+	if err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("get connection: %w", err)
+	}
+	if conn.Role != "presenter" {
+		return h.sendError(ctx, connectionID, "only presenter can open a poll", deps)
+	}
+
+	state, err := h.pollGet.Get(ctx, msg.PollID, connectionID, msg.Options, msg.MaxChoices, true)
+	if err != nil {
+		return events.APIGatewayProxyResponse{StatusCode: 500}, fmt.Errorf("poll_open: %w", err)
+	}
+
+	return h.broadcastPollState(ctx, state, deps)
 }
 
 // handlePollGet はアンケート状態取得メッセージを処理する。

--- a/presenter/cmd/message/main_test.go
+++ b/presenter/cmd/message/main_test.go
@@ -994,6 +994,168 @@ func TestHandle_PollSwitchInternalError(t *testing.T) {
 	}
 }
 
+// TestHandle_PollOpen はアンケート開始の正常処理を検証する。
+func TestHandle_PollOpen(t *testing.T) {
+	t.Parallel()
+	var broadcastCalled bool
+	h := newTestHandler(testHandlerOpts{
+		connGetter: &mockConnectionGetter{
+			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
+				return &connection.Connection{Role: "presenter"}, nil
+			},
+		},
+		pollGet: &mockPollGetter{
+			getFn: func(_ context.Context, pollID, _ string, options []string, maxChoices int, isPresenter bool) (*poll.PollState, error) {
+				if !isPresenter {
+					t.Error("expected isPresenter to be true")
+				}
+				if pollID != "q1" {
+					t.Errorf("expected pollID q1, got %s", pollID)
+				}
+				return defaultPollState(), nil
+			},
+		},
+		broadcaster: &mockMessageBroadcaster{
+			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+				broadcastCalled = true
+				return nil
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1","options":["A","B"],"maxChoices":1}`)
+	resp, err := h.handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !broadcastCalled {
+		t.Error("expected broadcast to be called")
+	}
+}
+
+// TestHandle_PollOpenMissingFields は poll_open の必須フィールド未指定時のエラーを検証する。
+func TestHandle_PollOpenMissingFields(t *testing.T) {
+	t.Parallel()
+	var sentPayload []byte
+	h := newTestHandler(testHandlerOpts{
+		singleSender: &mockSingleSender{
+			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
+				sentPayload = payload
+				return nil
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1"}`)
+	resp, err := h.handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(sentPayload), "required") {
+		t.Errorf("expected validation error, got %s", string(sentPayload))
+	}
+}
+
+// TestHandle_PollOpenNotPresenter はビューアーからの poll_open 拒否を検証する。
+func TestHandle_PollOpenNotPresenter(t *testing.T) {
+	t.Parallel()
+	var sentPayload []byte
+	h := newTestHandler(testHandlerOpts{
+		connGetter: &mockConnectionGetter{
+			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
+				return &connection.Connection{Role: "viewer"}, nil
+			},
+		},
+		singleSender: &mockSingleSender{
+			sendToOneFn: func(_ context.Context, _, _ string, payload []byte) error {
+				sentPayload = payload
+				return nil
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1","options":["A","B"],"maxChoices":1}`)
+	resp, err := h.handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(sentPayload), "only presenter") {
+		t.Errorf("expected presenter-only error, got %s", string(sentPayload))
+	}
+}
+
+// TestHandle_PollOpenConnError は poll_open の接続情報取得エラーを検証する。
+func TestHandle_PollOpenConnError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(testHandlerOpts{
+		connGetter: &mockConnectionGetter{
+			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
+				return nil, fmt.Errorf("conn error")
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1","options":["A","B"],"maxChoices":1}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestHandle_PollOpenGetError は poll_open のアンケート初期化エラーを検証する。
+func TestHandle_PollOpenGetError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(testHandlerOpts{
+		connGetter: &mockConnectionGetter{
+			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
+				return &connection.Connection{Role: "presenter"}, nil
+			},
+		},
+		pollGet: &mockPollGetter{
+			getFn: func(_ context.Context, _, _ string, _ []string, _ int, _ bool) (*poll.PollState, error) {
+				return nil, fmt.Errorf("init error")
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1","options":["A","B"],"maxChoices":1}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestHandle_PollOpenBroadcastError は poll_open のブロードキャストエラーを検証する。
+func TestHandle_PollOpenBroadcastError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(testHandlerOpts{
+		connGetter: &mockConnectionGetter{
+			getFn: func(_ context.Context, _, _ string) (*connection.Connection, error) {
+				return &connection.Connection{Role: "presenter"}, nil
+			},
+		},
+		pollGet: &mockPollGetter{
+			getFn: func(_ context.Context, _, _ string, _ []string, _ int, _ bool) (*poll.PollState, error) {
+				return defaultPollState(), nil
+			},
+		},
+		broadcaster: &mockMessageBroadcaster{
+			sendFn: func(_ context.Context, _ string, _ []byte, _ string) error {
+				return fmt.Errorf("broadcast error")
+			},
+		},
+	})
+	req := newRequest("conn1", `{"type":"poll_open","pollId":"q1","options":["A","B"],"maxChoices":1}`)
+	_, err := h.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 // TestHandle_UnknownType は不明メッセージタイプ時のエラーレスポンスを検証する。
 func TestHandle_UnknownType(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Add `poll_open` message type to the WebSocket handler so presenters can start a poll and broadcast it to all connected viewers
- Previously only `poll_get` existed which sends poll state to the requester only; `poll_open` initializes the poll and broadcasts `poll_state` to everyone
- Update frontend `PresenterStep` union to include `PollOpenPayload`, enabling poll steps in the presentation sequence

## Test plan
- [x] Go tests pass with 100% coverage including 6 new poll_open test cases
- [x] Frontend vitest passes (179 tests across 15 files)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プレゼンターはプレゼンテーション中にポーリング機能を実行できるようになりました。選択肢とポーリングIDの指定により、参加者投票をより柔軟に管理できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->