### PR TITLE
Change terminal pane layout to vertical split and add padding

### DIFF
--- a/front/src/components/CommandInput.tsx
+++ b/front/src/components/CommandInput.tsx
@@ -77,7 +77,7 @@ const CommandInput = ({ onSubmit, disabled, placeholder }: Props): ReactNode => 
           flex: 1,
           padding: "8px",
           fontFamily: "monospace",
-          fontSize: "clamp(14px, 4vw, 16px)",
+          fontSize: "18px",
           boxSizing: "border-box",
           minWidth: 0,
         }}
@@ -90,7 +90,7 @@ const CommandInput = ({ onSubmit, disabled, placeholder }: Props): ReactNode => 
         style={{
           padding: "8px 16px",
           fontFamily: "monospace",
-          fontSize: "clamp(14px, 4vw, 16px)",
+          fontSize: "18px",
           cursor: disabled || !value.trim() ? "default" : "pointer",
           whiteSpace: "nowrap",
         }}

--- a/front/src/components/Terminal.tsx
+++ b/front/src/components/Terminal.tsx
@@ -33,7 +33,7 @@ const Terminal = forwardRef<TerminalHandle>((_, ref) => {
     const el = containerRef.current;
     if (!el) return;
 
-    const xterm = new XTerm({ convertEol: true });
+    const xterm = new XTerm({ convertEol: true, fontSize: 18 });
     const fitAddon = new FitAddon();
     xterm.loadAddon(fitAddon);
     xterm.open(el);

--- a/front/src/slides/TerminalSlide.tsx
+++ b/front/src/slides/TerminalSlide.tsx
@@ -12,7 +12,7 @@ interface TerminalSlideProps {
   commands: string[];
 }
 
-/** Slide component with one or more terminal panes arranged side by side. */
+/** Slide component with one or more terminal panes stacked vertically. */
 export const TerminalSlide = ({
   sessionStatus,
   instruction,
@@ -44,8 +44,10 @@ export const TerminalSlide = ({
       <div
         style={{
           display: "flex",
+          flexDirection: "column",
           flex: 1,
           gap: "4px",
+          padding: "0 16px 16px",
           minHeight: 0,
         }}
       >

--- a/front/src/slides/TerminalSlide.tsx
+++ b/front/src/slides/TerminalSlide.tsx
@@ -25,6 +25,8 @@ export const TerminalSlide = ({
         flexDirection: "column",
         width: "100%",
         height: "100%",
+        padding: "16px",
+        boxSizing: "border-box",
         background: "#000",
       }}
     >
@@ -47,7 +49,6 @@ export const TerminalSlide = ({
           flexDirection: "column",
           flex: 1,
           gap: "4px",
-          padding: "0 16px 16px",
           minHeight: 0,
         }}
       >


### PR DESCRIPTION
## Summary
- Change terminal pane split direction from horizontal (side-by-side) to vertical (stacked) - closes #30
- Add padding around terminal panes container - closes #31
- Increase xterm.js font size from default (15) to 18

## Test plan
- [x] TerminalSlide tests pass (15/15)
- [ ] Visual check: terminal panes stack vertically with padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コマンド入力とターミナルのフォントサイズを18pxの固定サイズに統一し、レスポンシブレイアウト全体での表示サイズの一貫性を向上させました。

* **改善**
  * ターミナルペインのレイアウトをサイドバイサイド表示から垂直スタック表示に変更しました。
  * スライドのパディングと境界線ボックスサイジングを調整し、より洗練されたスペーシングを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->