### PR TITLE
Fix audit log to record client real IP instead of ALB internal IP

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -47,7 +47,7 @@ http {
             proxy_pass $runner_url$request_uri;
             proxy_http_version 1.1;
             proxy_set_header Connection '';
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Port $server_port;
             proxy_hide_header X-Runner-Url;
 
@@ -66,7 +66,7 @@ http {
             add_header X-Session-Reassigned $session_reassigned;
 
             proxy_pass $runner_url$request_uri;
-            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Port $server_port;
             proxy_hide_header X-Runner-Url;
         }

--- a/runner/handler.go
+++ b/runner/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -127,7 +128,7 @@ func handleExecute(sm *SessionManager, v Validator) gin.HandlerFunc {
 		}
 
 		class := classifyCommand(req.Command)
-		remote := c.ClientIP()
+		remote := clientIP(c)
 		auditLog(id, remote, class, req.Command, nil, nil)
 
 		if class == "validated" {
@@ -199,4 +200,19 @@ func auditLog(session, remote, class, command string, exitCode *int, err error) 
 func writeSSE(w http.ResponseWriter, event sseEvent) {
 	data, _ := json.Marshal(event)
 	fmt.Fprintf(w, "data: %s\n\n", data)
+}
+
+// clientIP extracts the client IP address from the request.
+// It prefers the CloudFront-Viewer-Address header set by CloudFront,
+// stripping the port suffix if present. If the header is absent,
+// it falls back to Gin's c.ClientIP which parses X-Forwarded-For.
+func clientIP(c *gin.Context) string {
+	if addr := c.GetHeader("CloudFront-Viewer-Address"); addr != "" {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return addr
+		}
+		return host
+	}
+	return c.ClientIP()
 }

--- a/runner/handler.go
+++ b/runner/handler.go
@@ -48,6 +48,7 @@ type sseEvent struct {
 func newHandler(sm *SessionManager, v Validator) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
+	r.SetTrustedProxies([]string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"})
 	r.HandleMethodNotAllowed = true
 	r.GET("/health", handleHealth())
 	r.POST("/api/session", handleCreateSession(sm))
@@ -126,7 +127,7 @@ func handleExecute(sm *SessionManager, v Validator) gin.HandlerFunc {
 		}
 
 		class := classifyCommand(req.Command)
-		remote := c.ClientIP() + ":" + c.GetHeader("X-Forwarded-Port")
+		remote := c.ClientIP()
 		auditLog(id, remote, class, req.Command, nil, nil)
 
 		if class == "validated" {

--- a/runner/handler_test.go
+++ b/runner/handler_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -656,6 +659,114 @@ func TestHealth(t *testing.T) {
 	}
 	if got := w.Body.String(); got != "ok\n" {
 		t.Fatalf("body = %q, want %q", got, "ok\n")
+	}
+}
+
+// TestExecuteCloudFrontViewerAddress verifies that when the CloudFront-Viewer-Address
+// header is present, handleExecute uses it as the remote IP in audit logs instead of c.ClientIP.
+func TestExecuteCloudFrontViewerAddress(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	sm := NewSessionManager()
+	defer sm.CloseAll()
+	sm.newShell = func() (Shell, error) {
+		return &mockShell{exitCode: 0}, nil
+	}
+	handler := newHandler(sm, nil)
+
+	id, _, err := sm.Create()
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	body := strings.NewReader(`{"command":"ls"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/execute", body)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: id})
+	req.Header.Set("CloudFront-Viewer-Address", "203.0.113.50:12345")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "remote=203.0.113.50") {
+		t.Fatalf("expected audit log to contain remote=203.0.113.50, got:\n%s", logOutput)
+	}
+}
+
+// TestExecuteCloudFrontViewerAddressWithoutPort verifies that when the
+// CloudFront-Viewer-Address header contains only an IP without port,
+// it is used as-is for the remote field in audit logs.
+func TestExecuteCloudFrontViewerAddressWithoutPort(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	sm := NewSessionManager()
+	defer sm.CloseAll()
+	sm.newShell = func() (Shell, error) {
+		return &mockShell{exitCode: 0}, nil
+	}
+	handler := newHandler(sm, nil)
+
+	id, _, err := sm.Create()
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	body := strings.NewReader(`{"command":"ls"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/execute", body)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: id})
+	req.Header.Set("CloudFront-Viewer-Address", "203.0.113.99")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "remote=203.0.113.99") {
+		t.Fatalf("expected audit log to contain remote=203.0.113.99, got:\n%s", logOutput)
+	}
+}
+
+// TestExecuteFallbackClientIP verifies that when the CloudFront-Viewer-Address
+// header is absent, handleExecute falls back to c.ClientIP for the remote field.
+func TestExecuteFallbackClientIP(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	sm := NewSessionManager()
+	defer sm.CloseAll()
+	sm.newShell = func() (Shell, error) {
+		return &mockShell{exitCode: 0}, nil
+	}
+	handler := newHandler(sm, nil)
+
+	id, _, err := sm.Create()
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+
+	body := strings.NewReader(`{"command":"ls"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/execute", body)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: id})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "remote=192.0.2.1") {
+		t.Fatalf("expected audit log to contain remote=192.0.2.1, got:\n%s", logOutput)
 	}
 }
 

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -31,7 +31,10 @@ resource "aws_cloudfront_origin_request_policy" "api_all_viewer" {
     cookie_behavior = "all"
   }
   headers_config {
-    header_behavior = "allViewer"
+    header_behavior = "allViewerAndWhitelistCloudFront"
+    headers {
+      items = ["CloudFront-Viewer-Address"]
+    }
   }
   query_strings_config {
     query_string_behavior = "all"


### PR DESCRIPTION
## Summary

- Nginx: Change `X-Forwarded-For` from `$remote_addr` to `$proxy_add_x_forwarded_for` to preserve the CloudFront→ALB IP chain instead of overwriting it with ALB's internal IP
- Runner: Set `TrustedProxies` to RFC 1918 ranges so `c.ClientIP()` correctly extracts the first non-private IP from the X-Forwarded-For chain
- Runner: Remove meaningless `X-Forwarded-Port` (Nginx's `$server_port` = 8080) from audit log `remote` field, log IP only

## Test plan

- [x] `docker build --target test runner/` passes with 100% coverage
- [x] Nginx config test passes via pre-commit hook
- [ ] After deploy, verify `remote=` in audit logs shows client global IP instead of `10.x.x.x:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * プロキシされたリクエストにおけるクライアントIP検出の精度を向上させました。複数のプロキシを経由するリクエストに対して、より正確なIPアドレスの追跡が可能になります。
  * 特定のプライベートネットワーク範囲からのプロキシを信頼できるものとして認識するよう設定を更新しました。
  * 監査ログの記録形式を簡潔にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->