### PR TITLE
Remove HandsOn step from presenter sequence

### DIFF
--- a/front/src/presenter/PresenterPanel.test.tsx
+++ b/front/src/presenter/PresenterPanel.test.tsx
@@ -7,8 +7,8 @@ vi.mock("./sequence", async () => {
   return {
     defaultSequence: [
       { type: Action.SlideSync, page: 0 },
-      { type: Action.HandsOn, instruction: "Run echo", placeholder: "echo hello" },
       { type: Action.SlideSync, page: 1 },
+      { type: Action.SlideSync, page: 2 },
     ],
   };
 });
@@ -16,11 +16,9 @@ vi.mock("./sequence", async () => {
 /** Creates a fresh set of props with mock send functions for each test. */
 const createProps = (): PresenterPanelProps & {
   sendSlideSync: Mock;
-  sendHandsOn: Mock;
   sendPollOpen: Mock;
 } => ({
   sendSlideSync: vi.fn(),
-  sendHandsOn: vi.fn(),
   sendPollOpen: vi.fn(),
   viewerCount: 0,
 });
@@ -64,12 +62,11 @@ describe("PresenterPanel", () => {
     expect(screen.getByRole("button", { name: "Next" }).hasAttribute("disabled")).toBe(false);
   });
 
-  /** Verify that advancing calls sendHandsOn for the hands_on step. */
-  it("advances step and calls sendHandsOn on next", async () => {
+  /** Verify that advancing calls sendSlideSync for the next step. */
+  it("advances step and calls sendSlideSync on next", async () => {
     await renderPanel();
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    expect(props.sendHandsOn).toHaveBeenCalledWith("Run echo", "echo hello");
-    expect(props.sendHandsOn).toHaveBeenCalledTimes(1);
+    expect(props.sendSlideSync).toHaveBeenCalledWith(1);
     expect(screen.getByText(/Step 2 \/ 3/)).toBeTruthy();
   });
 
@@ -94,8 +91,7 @@ describe("PresenterPanel", () => {
   it("advances step on ArrowRight key", async () => {
     await renderPanel();
     fireEvent.keyDown(window, { key: "ArrowRight" });
-    expect(props.sendHandsOn).toHaveBeenCalledWith("Run echo", "echo hello");
-    expect(props.sendHandsOn).toHaveBeenCalledTimes(1);
+    expect(props.sendSlideSync).toHaveBeenCalledWith(1);
     expect(screen.getByText(/Step 2 \/ 3/)).toBeTruthy();
   });
 
@@ -134,12 +130,5 @@ describe("PresenterPanel", () => {
   it("displays step description for slide_sync step", async () => {
     await renderPanel();
     expect(screen.getByText("Slide 0")).toBeTruthy();
-  });
-
-  /** Verify that hands_on step shows the correct description. */
-  it("displays step description for hands_on step", async () => {
-    await renderPanel();
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    expect(screen.getByText("Hands-on: Run echo")).toBeTruthy();
   });
 });

--- a/front/src/presenter/PresenterPanel.tsx
+++ b/front/src/presenter/PresenterPanel.tsx
@@ -6,8 +6,6 @@ import { defaultSequence, type PresenterStep } from "./sequence";
 export interface PresenterPanelProps {
   /** Sends a slide_sync message to synchronize viewers to a given page. */
   sendSlideSync: (page: number) => void;
-  /** Sends a hands_on message with instruction and placeholder text. */
-  sendHandsOn: (instruction: string, placeholder: string) => void;
   /** Sends a poll_open message to start a poll for viewers. */
   sendPollOpen: (pollId: string, options: string[], maxChoices: number) => void;
   /** Number of currently connected viewers. */
@@ -19,8 +17,6 @@ const describeStep = (step: PresenterStep): string => {
   switch (step.type) {
     case Action.SlideSync:
       return `Slide ${step.page}`;
-    case Action.HandsOn:
-      return `Hands-on: ${step.instruction}`;
     case Action.PollOpen:
       return `Poll: ${step.pollId}`;
   }
@@ -29,7 +25,6 @@ const describeStep = (step: PresenterStep): string => {
 /** Presenter control panel that drives the presentation sequence via step navigation. */
 export const PresenterPanel = ({
   sendSlideSync,
-  sendHandsOn,
   sendPollOpen,
   viewerCount,
 }: PresenterPanelProps): ReactNode => {
@@ -44,15 +39,12 @@ export const PresenterPanel = ({
         case Action.SlideSync:
           sendSlideSync(step.page);
           break;
-        case Action.HandsOn:
-          sendHandsOn(step.instruction, step.placeholder);
-          break;
         case Action.PollOpen:
           sendPollOpen(step.pollId, step.options, step.maxChoices);
           break;
       }
     },
-    [sendSlideSync, sendHandsOn, sendPollOpen],
+    [sendSlideSync, sendPollOpen],
   );
 
   /** Navigates to a specific step index. */

--- a/front/src/presenter/main.tsx
+++ b/front/src/presenter/main.tsx
@@ -43,12 +43,11 @@ const PresenterApp = (): ReactNode => {
 
 /** Inner component rendered after login that connects the usePresenter hook to the PresenterPanel. */
 const PresenterAppInner = (): ReactNode => {
-  const { viewerCount, sendSlideSync, sendHandsOn, sendPollOpen } = usePresenter(wsUrl());
+  const { viewerCount, sendSlideSync, sendPollOpen } = usePresenter(wsUrl());
 
   return (
     <PresenterPanel
       sendSlideSync={sendSlideSync}
-      sendHandsOn={sendHandsOn}
       sendPollOpen={sendPollOpen}
       viewerCount={viewerCount}
     />

--- a/front/src/presenter/sequence.test.ts
+++ b/front/src/presenter/sequence.test.ts
@@ -9,12 +9,13 @@ describe("buildSequence", () => {
     expect(buildSequence([])).toEqual([]);
   });
 
-  /** Verify that non-terminal, non-poll slides produce only SlideSync steps. */
-  it("generates SlideSync for non-terminal slides", () => {
-    const data = [{ type: "title" }, { type: "text" }];
+  /** Verify that non-poll slides produce only SlideSync steps. */
+  it("generates SlideSync for all non-poll slides", () => {
+    const data = [{ type: "title" }, { type: "text" }, { type: "terminal" }];
     expect(buildSequence(data)).toEqual([
       { type: Action.SlideSync, page: 0 },
       { type: Action.SlideSync, page: 1 },
+      { type: Action.SlideSync, page: 2 },
     ]);
   });
 
@@ -41,39 +42,6 @@ describe("buildSequence", () => {
       { type: Action.SlideSync, page: 1 },
     ]);
   });
-
-  /** Verify that terminal slides produce SlideSync followed by HandsOn. */
-  it("inserts HandsOn step after terminal slides", () => {
-    const data = [
-      { type: "text" },
-      { type: "terminal", instruction: "Run it", commands: ["echo hello", "date"] },
-      { type: "text" },
-    ];
-    expect(buildSequence(data)).toEqual([
-      { type: Action.SlideSync, page: 0 },
-      { type: Action.SlideSync, page: 1 },
-      { type: Action.HandsOn, instruction: "Run it", placeholder: "echo hello\ndate" },
-      { type: Action.SlideSync, page: 2 },
-    ]);
-  });
-
-  /** Verify that terminal slides with empty instruction and commands produce correct defaults. */
-  it("handles terminal slide with empty instruction and commands", () => {
-    const data = [{ type: "terminal", instruction: "", commands: [] }];
-    expect(buildSequence(data)).toEqual([
-      { type: Action.SlideSync, page: 0 },
-      { type: Action.HandsOn, instruction: "", placeholder: "" },
-    ]);
-  });
-
-  /** Verify that terminal slides without optional fields default gracefully. */
-  it("handles terminal slide with missing optional fields", () => {
-    const data = [{ type: "terminal" }];
-    expect(buildSequence(data)).toEqual([
-      { type: Action.SlideSync, page: 0 },
-      { type: Action.HandsOn, instruction: "", placeholder: "" },
-    ]);
-  });
 });
 
 describe("defaultSequence", () => {
@@ -89,11 +57,10 @@ describe("defaultSequence", () => {
     expect(first).toEqual({ type: Action.SlideSync, page: 0 });
   });
 
-  /** Verify that the sequence length matches slideData count plus HandsOn and PollOpen steps. */
+  /** Verify that the sequence length matches slideData count plus PollOpen steps. */
   it("has correct length based on slideData", () => {
-    const terminalCount = slideData.filter((s) => s.type === "terminal").length;
     const pollCount = slideData.filter((s) => s.type === "poll").length;
-    expect(defaultSequence).toHaveLength(slideData.length + terminalCount + pollCount);
+    expect(defaultSequence).toHaveLength(slideData.length + pollCount);
   });
 
   /** Verify that every slide page index appears as a SlideSync step. */
@@ -118,20 +85,6 @@ describe("PresenterStep discriminated union", () => {
     }
   });
 
-  /** Verify that a hands_on step carries instruction and placeholder properties. */
-  it("allows hands_on with instruction and placeholder", () => {
-    const step: PresenterStep = {
-      type: Action.HandsOn,
-      instruction: "Run the command",
-      placeholder: "echo hello",
-    };
-    expect(step.type).toBe(Action.HandsOn);
-    if (step.type === Action.HandsOn) {
-      expect(step.instruction).toBe("Run the command");
-      expect(step.placeholder).toBe("echo hello");
-    }
-  });
-
   /** Verify that a poll_open step carries pollId, options, and maxChoices properties. */
   it("allows poll_open with pollId, options, and maxChoices", () => {
     const step: PresenterStep = {
@@ -152,11 +105,10 @@ describe("PresenterStep discriminated union", () => {
   it("collects expected ordered types", () => {
     const steps: PresenterStep[] = [
       { type: Action.SlideSync, page: 1 },
-      { type: Action.HandsOn, instruction: "do it", placeholder: "cmd" },
       { type: Action.PollOpen, pollId: "q1", options: ["A"], maxChoices: 1 },
     ];
 
     const types = steps.map((s) => s.type);
-    expect(types).toEqual([Action.SlideSync, Action.HandsOn, Action.PollOpen]);
+    expect(types).toEqual([Action.SlideSync, Action.PollOpen]);
   });
 });

--- a/front/src/presenter/sequence.ts
+++ b/front/src/presenter/sequence.ts
@@ -1,4 +1,4 @@
-import { Action, type HandsOnPayload, type SlideSyncPayload } from "../api/presenter";
+import { Action, type SlideSyncPayload } from "../api/presenter";
 import { slideData } from "../slides/slideData";
 
 /** Poll open payload used only in presenter steps to initialize a poll for viewers. */
@@ -11,32 +11,23 @@ export type PollOpenPayload = {
 
 /**
  * Discriminated union type representing a single display-mode step in the presentation sequence.
- * SlideSyncPayload and HandsOnPayload are shared with server-to-client message types.
+ * SlideSyncPayload is shared with server-to-client message types.
  */
-export type PresenterStep = SlideSyncPayload | HandsOnPayload | PollOpenPayload;
+export type PresenterStep = SlideSyncPayload | PollOpenPayload;
 
-/** Input shape accepted by buildSequence covering terminal and poll slides. */
+/** Input shape accepted by buildSequence covering poll slides. */
 type BuildSequenceInput = ReadonlyArray<{
   type: string;
-  instruction?: string;
-  commands?: string[];
   pollId?: string;
   options?: string[];
 }>;
 
-/** Generates the presentation sequence from slideData, inserting HandsOn steps after terminal slides and PollOpen steps after poll slides. */
+/** Generates the presentation sequence from slideData, inserting PollOpen steps after poll slides. */
 export const buildSequence = (data: BuildSequenceInput): PresenterStep[] => {
   const steps: PresenterStep[] = [];
   for (let i = 0; i < data.length; i++) {
     steps.push({ type: Action.SlideSync, page: i });
     const slide = data[i];
-    if (slide.type === "terminal") {
-      steps.push({
-        type: Action.HandsOn,
-        instruction: slide.instruction ?? "",
-        placeholder: (slide.commands ?? []).join("\n"),
-      });
-    }
     if (slide.type === "poll" && slide.pollId && slide.options) {
       steps.push({
         type: Action.PollOpen,


### PR DESCRIPTION
## Summary
- Remove `HandsOnPayload` from the presenter `PresenterStep` union type and `buildSequence` logic
- Remove `sendHandsOn` prop from `PresenterPanel` and its wiring in `main.tsx`
- Terminal slides now only produce `SlideSync` steps — the viewer already shows the terminal UI via `slide_sync`

## Note
The backend `hands_on` handler and `usePresenter.sendHandsOn` remain untouched — they are still used by the viewer-side WebSocket protocol.

## Test plan
- [x] `nix develop -c pnpm vp test` — all 175 tests pass
- [x] Pre-commit hooks pass (formatting, lint, gitleaks, trivy, checkov)

🤖 Generated with [Claude Code](https://claude.com/claude-code)