### PR TITLE
Preserve viewer source port in audit log for MAP-E client identification

### DIFF
--- a/runner/handler.go
+++ b/runner/handler.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -202,17 +201,16 @@ func writeSSE(w http.ResponseWriter, event sseEvent) {
 	fmt.Fprintf(w, "data: %s\n\n", data)
 }
 
-// clientIP extracts the client IP address from the request.
+// clientIP extracts the client address from the request.
 // It prefers the CloudFront-Viewer-Address header set by CloudFront,
-// stripping the port suffix if present. If the header is absent,
-// it falls back to Gin's c.ClientIP which parses X-Forwarded-For.
+// which contains the viewer IP and source port in ip:port format.
+// The source port is preserved because it helps identify clients
+// behind MAP-E or DS-Lite where multiple households share a single
+// global IP and are distinguished by port ranges.
+// If the header is absent, it falls back to Gin's c.ClientIP.
 func clientIP(c *gin.Context) string {
 	if addr := c.GetHeader("CloudFront-Viewer-Address"); addr != "" {
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			return addr
-		}
-		return host
+		return addr
 	}
 	return c.ClientIP()
 }

--- a/runner/handler_test.go
+++ b/runner/handler_test.go
@@ -663,7 +663,8 @@ func TestHealth(t *testing.T) {
 }
 
 // TestExecuteCloudFrontViewerAddress verifies that when the CloudFront-Viewer-Address
-// header is present, handleExecute uses it as the remote IP in audit logs instead of c.ClientIP.
+// header is present, handleExecute uses the full ip:port value as the remote field
+// in audit logs to support client identification behind MAP-E or DS-Lite.
 func TestExecuteCloudFrontViewerAddress(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)
@@ -693,45 +694,8 @@ func TestExecuteCloudFrontViewerAddress(t *testing.T) {
 	}
 
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "remote=203.0.113.50") {
-		t.Fatalf("expected audit log to contain remote=203.0.113.50, got:\n%s", logOutput)
-	}
-}
-
-// TestExecuteCloudFrontViewerAddressWithoutPort verifies that when the
-// CloudFront-Viewer-Address header contains only an IP without port,
-// it is used as-is for the remote field in audit logs.
-func TestExecuteCloudFrontViewerAddressWithoutPort(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
-
-	sm := NewSessionManager()
-	defer sm.CloseAll()
-	sm.newShell = func() (Shell, error) {
-		return &mockShell{exitCode: 0}, nil
-	}
-	handler := newHandler(sm, nil)
-
-	id, _, err := sm.Create()
-	if err != nil {
-		t.Fatalf("Create() error: %v", err)
-	}
-
-	body := strings.NewReader(`{"command":"ls"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/execute", body)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: id})
-	req.Header.Set("CloudFront-Viewer-Address", "203.0.113.99")
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-	}
-
-	logOutput := buf.String()
-	if !strings.Contains(logOutput, "remote=203.0.113.99") {
-		t.Fatalf("expected audit log to contain remote=203.0.113.99, got:\n%s", logOutput)
+	if !strings.Contains(logOutput, "remote=203.0.113.50:12345") {
+		t.Fatalf("expected audit log to contain remote=203.0.113.50:12345, got:\n%s", logOutput)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve the full `ip:port` from `CloudFront-Viewer-Address` header in audit logs instead of stripping the port
- Source port is needed to identify clients behind MAP-E or DS-Lite where multiple households share a single global IP and are distinguished by port ranges
- Remove unused `net` import and simplify `clientIP()` function

## Test plan

- [x] `docker build --target test runner/` passes with 100% coverage
- [ ] After deploy, verify `remote=` in audit logs shows `ip:port` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * CloudFront経由のアクセスログに記録されるクライアントアドレスが、IPアドレスとポート番号の両方を含むようになりました。ソースポート情報が監査ログに正確に保持されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->