### PR TITLE
Fix TerminalPane height to viewport-based equal split

### DIFF
--- a/front/src/slides/TerminalPane.tsx
+++ b/front/src/slides/TerminalPane.tsx
@@ -41,7 +41,7 @@ export const TerminalPane = ({
       style={{
         display: "flex",
         flexDirection: "column",
-        height: height ?? undefined,
+        height,
         flex: height ? undefined : 1,
         flexShrink: height ? 0 : undefined,
         minWidth: 0,

--- a/front/src/slides/TerminalPane.tsx
+++ b/front/src/slides/TerminalPane.tsx
@@ -11,10 +11,16 @@ interface TerminalPaneProps {
   sessionStatus: SessionStatus;
   /** Placeholder text shown in the command input. */
   placeholder: string;
+  /** Explicit height for the pane. When omitted the pane stretches via flex. */
+  height?: string;
 }
 
 /** Single terminal with command input, used as a pane inside TerminalSlide. */
-export const TerminalPane = ({ sessionStatus, placeholder }: TerminalPaneProps): ReactNode => {
+export const TerminalPane = ({
+  sessionStatus,
+  placeholder,
+  height,
+}: TerminalPaneProps): ReactNode => {
   const ready = sessionStatus === "ready";
   const terminalRef = useRef<TerminalHandle>(null);
   const { run, running } = useExecute(ready, terminalRef);
@@ -35,7 +41,9 @@ export const TerminalPane = ({ sessionStatus, placeholder }: TerminalPaneProps):
       style={{
         display: "flex",
         flexDirection: "column",
-        flex: 1,
+        height: height ?? undefined,
+        flex: height ? undefined : 1,
+        flexShrink: height ? 0 : undefined,
         minWidth: 0,
       }}
     >

--- a/front/src/slides/TerminalSlide.tsx
+++ b/front/src/slides/TerminalSlide.tsx
@@ -53,7 +53,12 @@ export const TerminalSlide = ({
         }}
       >
         {commands.map((cmd, index) => (
-          <TerminalPane key={`${index}-${cmd}`} sessionStatus={sessionStatus} placeholder={cmd} />
+          <TerminalPane
+            key={`${index}-${cmd}`}
+            sessionStatus={sessionStatus}
+            placeholder={cmd}
+            height={`calc(95vh / ${commands.length})`}
+          />
         ))}
       </div>
     </div>

--- a/front/src/slides/TerminalSlide.tsx
+++ b/front/src/slides/TerminalSlide.tsx
@@ -57,7 +57,7 @@ export const TerminalSlide = ({
             key={`${index}-${cmd}`}
             sessionStatus={sessionStatus}
             placeholder={cmd}
-            height={`calc(95vh / ${commands.length})`}
+            height={`calc((98% - ${(commands.length - 1) * 4}px) / ${commands.length})`}
           />
         ))}
       </div>

--- a/front/src/slides/slideData.ts
+++ b/front/src/slides/slideData.ts
@@ -72,7 +72,7 @@ export const slideData: ReadonlyArray<SlideData> = [
     lines: ["まず、1から。", "お手元の画面で、実行ボタンを押すと`date`コマンドが実行できます。"],
   },
   { type: "terminal", instruction: "", commands: ["date"] },
-  { type: "text", lines: ["HST？\nホノルルは午前1時らしいです。\n大変ですね。"] },
+  { type: "text", lines: ["HST？\nホノルルは午前2時らしいです。\n大変ですね。"] },
   { type: "text", lines: ["事前に\nずらしておきました。"] },
   { type: "text", lines: ["設定を戻してくれや"] },
   { type: "terminal", instruction: "", commands: ["home-manager switch --rollback", "date"] },


### PR DESCRIPTION
## Summary
- Set each TerminalPane height to `calc(95vh / paneCount)` instead of relying on `flex: 1`
- Added optional `height` prop to TerminalPane; when set, uses fixed height with `flexShrink: 0`

## Test plan
- [ ] `cd front && pnpm vp dev` でローカル起動し、2ペインのTerminalSlideが各47.5vhになることを確認
- [ ] 1ペインのスライドが95vhになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ターミナルペインの高さ制御を改善しました。複数のコマンドペインが表示される場合、ビューポートの高さを自動的に分割してレイアウトされるようになり、より効率的な画面利用が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->