### PR TITLE
update README to match current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,28 @@ docker compose --profile broker --profile runner --profile nginx --profile front
 
 | サービス | ポート | 説明 |
 |---------|--------|------|
-| front | 5173 | Vite dev server |
-| nginx | 80 | リバースプロキシ |
-| broker | 8080 | 制御プレーン (DynamoDB) |
-| runner | 3000 | コマンド実行サーバー |
+| front | 5173 | Vite dev server (React + TypeScript) |
+| nginx | 8080 | リバースプロキシ |
+| broker | 8080 | 制御プレーン |
+| runner | 3000 | コマンド実行サーバ |
 | presenter | — | スライド同期・アンケート (AWS Lambda + API Gateway WebSocket) |
+| dynamodb-local | 8000 | ローカル開発用 DynamoDB |
+
+## アーキテクチャ
+
+```
+Client → CloudFront/ALB → NGINX → Runner
+                            ↓ (auth_request /_resolve)
+                          Broker ←→ DynamoDB
+```
+
+1. NGINX が `auth_request` で Broker に問い合わせ、セッションに対応する Runner を解決
+2. Broker はアイドル状態の Runner を割り当て、`runner_id` cookie を発行
+3. NGINX はリクエストを対応する Runner にプロキシ
 
 ## API
 
-### NGINX 経由
+### Runner
 
 | メソッド | パス | 説明 |
 |---------|------|------|
@@ -56,6 +69,7 @@ SSE イベント種別: `stdout` (リアルタイム), `stderr` (完了時), `co
 
 | メソッド | パス | 説明 |
 |---------|------|------|
+| GET | `/health` | ヘルスチェック |
 | GET | `/resolve` | セッション解決 or 新規作成 |
 | DELETE | `/sessions/{sessionId}` | セッション終了 |
 | POST | `/internal/runners/register` | Runner 登録 |
@@ -73,8 +87,10 @@ API Gateway WebSocket 経由で front と通信する。
 | S→C | `poll_state` | アンケート状態（選択肢・投票数・自分の選択） |
 | S→C | `poll_error` | アンケート操作エラー |
 | C→S | `slide_sync` | スライドページ送信（presenter ロール） |
+| C→S | `get_state` | 現在のスライド位置取得 |
 | C→S | `viewer_count` | 視聴者数取得 |
-| C→S | `poll_get` | アンケート取得・初期化 |
+| C→S | `poll_open` | アンケート開始（presenter ロール） |
+| C→S | `poll_get` | アンケート取得 |
 | C→S | `poll_vote` | 投票 |
 | C→S | `poll_unvote` | 投票取消 |
 | C→S | `poll_switch` | 投票変更 |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker compose --profile broker --profile runner --profile nginx --profile front
 
 ## アーキテクチャ
 
-```
+```text
 Client → CloudFront/ALB → NGINX → Runner
                             ↓ (auth_request /_resolve)
                           Broker ←→ DynamoDB
@@ -57,6 +57,7 @@ Client → CloudFront/ALB → NGINX → Runner
 
 | メソッド | パス | 説明 |
 |---------|------|------|
+| GET | `/health` | ヘルスチェック |
 | POST | `/api/session` | bash セッション作成。`session_id` cookie を返す |
 | DELETE | `/api/session` | bash セッション削除 |
 | POST | `/api/execute` | コマンド実行 (SSE ストリーム)。`{"command": "..."}` |


### PR DESCRIPTION
## Summary

- サービス一覧のポート・説明を現状のコードに合わせて修正 (nginx: 80→8080, 説明の詳細化)
- dynamodb-local をサービス一覧に追加
- アーキテクチャ図セクションを追加 (NGINX auth_request フロー)
- Broker API に `/health` エンドポイントを追加
- Presenter WebSocket に `get_state`, `poll_open` メッセージを追加、`poll_get` の説明を修正
- API セクション名を「NGINX 経由」→「Runner」に変更

## Test plan

- [ ] README の内容が実際のコードベースと一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント更新

* **Documentation**
  * サービス構成表を更新（NGINX ポート 8080、Broker 説明変更、DynamoDB ローカルサービス追加）
  * システムアーキテクチャセクションを追加（リクエストフロー、セッション解決フロー）
  * API ドキュメントを拡張（GET `/health` および `/resolve` エンドポイント追加）
  * WebSocket メッセージタイプを更新（`get_state`、`poll_open` 追加）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->