### PR TITLE
Disable all deploy workflows

### DIFF
--- a/.github/workflows/deploy-broker.yml
+++ b/.github/workflows/deploy-broker.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: false # deploy disabled: production environment removed
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: false # deploy disabled: production environment removed
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-nginx.yml
+++ b/.github/workflows/deploy-nginx.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: false # deploy disabled: production environment removed
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-presenter.yml
+++ b/.github/workflows/deploy-presenter.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: false # deploy disabled: production environment removed
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: false # deploy disabled: production environment removed
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Disable all 5 deploy workflows (front, nginx, runner, broker, presenter) by setting `if: false` on deploy jobs
- Original conditions are preserved as comments for easy re-enablement
- Production environment has been removed, so deploys should be skipped

## Test plan
- [ ] Verify deploy workflows are skipped on main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Chores**
  * 複数のデプロイメントワークフロー（broker、front、nginx、presenter、runner）の自動実行を無効化しました。これにより、該当するデプロイメント処理は自動実行されなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->