### PR TITLE
Migrate Bedrock model from Claude Sonnet 4 to Sonnet 4.6 with JP inference profile

### DIFF
--- a/runner/main.go
+++ b/runner/main.go
@@ -33,7 +33,7 @@ var registerFn = register
 var deregisterFn = deregister
 
 // defaultModelID is the Bedrock model used when BEDROCK_MODEL_ID is not set.
-const defaultModelID = "apac.anthropic.claude-sonnet-4-20250514-v1:0"
+const defaultModelID = "jp.anthropic.claude-sonnet-4-6"
 
 // newValidatorFn creates a Validator for LLM command safety checks.
 // It defaults to newBedrockValidatorFromEnv and can be replaced in tests.

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -122,13 +122,13 @@ resource "aws_iam_role_policy" "broker_dynamodb" {
   policy = data.aws_iam_policy_document.broker_dynamodb.json
 }
 
-# runner: Bedrock InvokeModel access via APAC inference profile
+# runner: Bedrock InvokeModel access via JP inference profile
 data "aws_iam_policy_document" "runner_bedrock" {
   statement {
     sid       = "AllowInferenceProfile"
     effect    = "Allow"
     actions   = ["bedrock:InvokeModel"]
-    resources = ["arn:aws:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:inference-profile/apac.anthropic.claude-sonnet-4-20250514-v1:0"]
+    resources = ["arn:aws:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:inference-profile/jp.anthropic.claude-sonnet-4-6"]
   }
 
   statement {
@@ -136,13 +136,13 @@ data "aws_iam_policy_document" "runner_bedrock" {
     effect  = "Allow"
     actions = ["bedrock:InvokeModel"]
     resources = [
-      for region in local.apac_cris_destination_regions :
-      "arn:aws:bedrock:${region}::foundation-model/anthropic.claude-sonnet-4-20250514-v1:0"
+      for region in local.jp_cris_destination_regions :
+      "arn:aws:bedrock:${region}::foundation-model/anthropic.claude-sonnet-4-6"
     ]
     condition {
       test     = "StringEquals"
       variable = "bedrock:InferenceProfileArn"
-      values   = ["arn:aws:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:inference-profile/apac.anthropic.claude-sonnet-4-20250514-v1:0"]
+      values   = ["arn:aws:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:inference-profile/jp.anthropic.claude-sonnet-4-6"]
     }
   }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -26,15 +26,9 @@ locals {
     websocket = "presenter-websocket-api"
   }
 
-  # Destination regions for APAC cross-region inference profile from ap-northeast-1
-  apac_cris_destination_regions = [
+  # Destination regions for JP cross-region inference profile from ap-northeast-1
+  jp_cris_destination_regions = [
     "ap-northeast-1",
-    "ap-northeast-2",
     "ap-northeast-3",
-    "ap-south-1",
-    "ap-south-2",
-    "ap-southeast-1",
-    "ap-southeast-2",
-    "ap-southeast-4",
   ]
 }


### PR DESCRIPTION
## Summary
- Migrate from deprecated Claude Sonnet 4 (`anthropic.claude-sonnet-4-20250514-v1:0`) to Claude Sonnet 4.6 (`anthropic.claude-sonnet-4-6`)
- Switch from APAC cross-region inference profile to JP inference profile (`jp.anthropic.claude-sonnet-4-6`)
- Update destination regions from 8 APAC regions to 2 JP regions (`ap-northeast-1`, `ap-northeast-3`)

## Motivation
AWS Health notification: Claude Sonnet 4 enters legacy status 2026-04-14, extended access 2026-07-14, and end-of-life 2026-10-14.

## Test plan
- [x] `docker build --target test runner/` passes with 100% coverage
- [ ] Verify `terraform plan` shows expected IAM policy changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)