### PR TITLE
Add WAF Web ACL and HTTPS listener to ALB

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,11 +1,10 @@
 # trivy:ignore:AVD-AWS-0054 -- ALB access logs are optional for initial deployment
-# trivy:ignore:AVD-AWS-0053 -- ALB is intentionally internet-facing, accessed via CloudFront
+# trivy:ignore:AVD-AWS-0053 -- ALB is intentionally internet-facing, protected by WAF
 resource "aws_lb" "main" {
   # checkov:skip=CKV_AWS_91:ALB access logs are optional for initial deployment
   drop_invalid_header_fields = true
-  # checkov:skip=CKV2_AWS_28:WAF is out of scope for initial deployment
+  # checkov:skip=CKV2_AWS_76:Log4j WAF rule is not needed, backend does not use Java
   # checkov:skip=CKV_AWS_150:Deletion protection is not needed for initial deployment
-  # checkov:skip=CKV2_AWS_20:HTTPS terminates at CloudFront, ALB uses HTTP
   name               = "bunshin"
   internal           = false
   load_balancer_type = "application"
@@ -17,9 +16,15 @@ resource "aws_lb" "main" {
   })
 }
 
-# trivy:ignore:AVD-AWS-0053 -- target group uses HTTP as HTTPS terminates at CloudFront
+# ACM certificate for ALB HTTPS listener
+data "aws_acm_certificate" "alb" {
+  domain   = var.domain_name
+  statuses = ["ISSUED"]
+}
+
+# trivy:ignore:AVD-AWS-0053 -- target group uses HTTP, HTTPS terminates at ALB
 resource "aws_lb_target_group" "nginx" {
-  # checkov:skip=CKV_AWS_378:HTTPS terminates at CloudFront, ALB uses HTTP
+  # checkov:skip=CKV_AWS_378:HTTPS terminates at ALB, target uses HTTP
   name        = "bunshin-nginx"
   port        = local.ecs_services["nginx"].port
   protocol    = "HTTP"
@@ -43,17 +48,40 @@ resource "aws_lb_target_group" "nginx" {
   })
 }
 
-# trivy:ignore:AVD-AWS-0054 -- ALB uses HTTP as HTTPS terminates at CloudFront
+# HTTPS listener with ACM certificate
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = data.aws_acm_certificate.alb.arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nginx.arn
+  }
+
+  tags = merge(local.common_tags, {
+    Service = "alb"
+  })
+}
+
+# HTTP listener redirects to HTTPS
 resource "aws_lb_listener" "http" {
-  # checkov:skip=CKV_AWS_2:HTTPS terminates at CloudFront, ALB uses HTTP
-  # checkov:skip=CKV_AWS_103:HTTPS terminates at CloudFront, ALB uses HTTP
+  # checkov:skip=CKV_AWS_2:HTTP listener is used for redirect to HTTPS only
+  # checkov:skip=CKV_AWS_103:HTTP listener is used for redirect to HTTPS only
   load_balancer_arn = aws_lb.main.arn
   port              = 80
   protocol          = "HTTP"
 
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.nginx.arn
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 
   tags = merge(local.common_tags, {

--- a/terraform/sg.tf
+++ b/terraform/sg.tf
@@ -13,20 +13,31 @@ resource "aws_security_group" "alb" {
   }
 }
 
-# ALB inbound: HTTP from CloudFront prefix list
-data "aws_ec2_managed_prefix_list" "cloudfront" {
-  name = "com.amazonaws.global.cloudfront.origin-facing"
+# ALB inbound: HTTPS from internet, access controlled by WAF
+# trivy:ignore:AVD-AWS-0107 -- ALB is internet-facing, WAF restricts access via header validation
+resource "aws_security_group_rule" "alb_ingress_https" {
+  # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS from internet, WAF controlled"
 }
 
-resource "aws_security_group_rule" "alb_ingress_cloudfront" {
+# ALB inbound: HTTP from internet for HTTPS redirect
+# trivy:ignore:AVD-AWS-0107 -- HTTP listener redirects to HTTPS
+resource "aws_security_group_rule" "alb_ingress_http" {
   # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
+  # checkov:skip=CKV_AWS_260:HTTP port 80 is used for HTTPS redirect only
   type              = "ingress"
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  prefix_list_ids   = [data.aws_ec2_managed_prefix_list.cloudfront.id]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.alb.id
-  description       = "HTTP from CloudFront"
+  description       = "HTTP from internet for HTTPS redirect"
 }
 
 # ALB outbound: to nginx

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,16 +1,17 @@
 variable "domain_name" {
-  description = "Custom domain name for CloudFront distribution"
-  type        = string
-}
-
-variable "acm_certificate_arn" {
-  description = "ARN of ACM certificate in us-east-1 for custom domain"
+  description = "Domain name for ALB ACM certificate lookup"
   type        = string
 }
 
 variable "aws_profile" {
   description = "AWS CLI profile name for the target account"
   type        = string
+}
+
+variable "proxy_secret" {
+  description = "Secret header value for Cloudflare Workers proxy verification via WAF"
+  type        = string
+  sensitive   = true
 }
 
 variable "runner_desired_count" {

--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,0 +1,63 @@
+# WAF Web ACL for ALB: default block, allow only requests with valid proxy secret
+resource "aws_wafv2_web_acl" "alb" {
+  # checkov:skip=CKV_AWS_192:Log4j protection is not needed, backend does not use Java
+  # checkov:skip=CKV2_AWS_31:WAF logging is not needed for initial deployment
+  name  = "bunshin-alb"
+  scope = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  # Allow requests with matching X-Proxy-Secret header from Cloudflare Workers
+  rule {
+    name     = "allow-proxy-secret"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        search_string = var.proxy_secret
+
+        field_to_match {
+          single_header {
+            name = "x-proxy-secret"
+          }
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+
+        positional_constraint = "EXACTLY"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "bunshin-allow-proxy-secret"
+    }
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "bunshin-alb-waf"
+  }
+
+  tags = merge(local.common_tags, {
+    Service = "waf"
+  })
+}
+
+# Associate WAF Web ACL with ALB
+resource "aws_wafv2_web_acl_association" "alb" {
+  # checkov:skip=CKV_BUNSHIN_1:Resource does not support tags
+  resource_arn = aws_lb.main.arn
+  web_acl_arn  = aws_wafv2_web_acl.alb.arn
+}


### PR DESCRIPTION
## Summary
- Add WAF Web ACL with `X-Proxy-Secret` header validation (default block)
- Add HTTPS listener with ACM certificate lookup via `data "aws_acm_certificate"`
- Convert HTTP listener to HTTPS redirect
- Update ALB security group: CloudFront prefix list → 0.0.0.0/0:443 + :80 for redirect
- Add `proxy_secret` and keep `domain_name` variables

## Test plan
- [x] `terraform validate` passes
- [x] All lefthook pre-commit checks pass (gitleaks, trivy, checkov, tflint, terraform fmt)
- [ ] Set `proxy_secret` and `domain_name` in tfvars before `terraform apply`
- [ ] Verify WAF blocks requests without `X-Proxy-Secret` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)